### PR TITLE
Exclude additional columns from XML properties column

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,5 @@ var log = new LoggerConfiguration()
     .CreateLogger();
 ```
 The log event properties `User` and `Other` will now be placed in the corresponding column upon logging. The property name must match a column name in your table.
+
+By default the additional properties will still be included in the XML data saved to the Properties column (assuming that is not disabled). That's consistent with the idea behind structured logging, and makes it easier to convert the log data to another (NoSql) storage platform later if desired.  However, if the data is to stay in SQL Server, then the additional properties may not need to be saved in both columns and XML, so an option in the sink configuration allows you to exclude those properties from the XML.

--- a/src/Serilog.Sinks.MSSqlServer/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/LoggerConfigurationMSSqlServerExtensions.cs
@@ -40,24 +40,39 @@ namespace Serilog
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="storeTimestampInUtc">Store Timestamp In UTC</param>
         /// <param name="additionalDataColumns">Additional columns for data storage.</param>
+        /// <param name="excludeAdditionalColumnsFromProperties">Exclude properties from the Properties column if they are being saved to additional columns.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration MSSqlServer(
             this LoggerSinkConfiguration loggerConfiguration,
-            string connectionString, string tableName, bool storeProperties = true,
+            string connectionString,
+            string tableName,
+            bool storeProperties = true,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             int batchPostingLimit = MSSqlServerSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
             bool storeTimestampInUtc = false,
-            DataColumn[] additionalDataColumns = null)
+            DataColumn[] additionalDataColumns = null,
+            bool excludeAdditionalColumnsFromProperties = false
+            )
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
 
             var defaultedPeriod = period ?? MSSqlServerSink.DefaultPeriod;
 
             return loggerConfiguration.Sink(
-                new MSSqlServerSink(connectionString, tableName, storeProperties, batchPostingLimit, defaultedPeriod, formatProvider, storeTimestampInUtc, additionalDataColumns),
+                new MSSqlServerSink(
+                    connectionString,
+                    tableName,
+                    storeProperties,
+                    batchPostingLimit,
+                    defaultedPeriod,
+                    formatProvider,
+                    storeTimestampInUtc,
+                    additionalDataColumns,
+                    excludeAdditionalColumnsFromProperties
+                    ),
                 restrictedToMinimumLevel);
         }
     }


### PR DESCRIPTION
If a property is being saved to a column it doesn't necessarily need to be included in the XML blob too. (SQL Server queries would use the column anyway.)  If the values aren't needed in the XML then it's cleaner to avoid the redundancy.