### PR TITLE
Configure SQL Columns 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ If you are configuring Serilog with the `ReadFrom.AppSettings()` XML configurati
 <add key="serilog:write-to:MSSqlServer.tableName" value="Logs"/>
 ```
 
+In addition, columns can be defined with the name and data type of the column in SQL Server. Columns specified must match database table exactly. DataType is case sensitive, based on SQL type (excluding precision/length). 
+```xml
+  <configSections>
+    <section name="MSSqlServerSettingsSection" type="Serilog.Configuration.MSSqlServerConfigurationSection, Serilog.Sinks.MSSqlServer"/>
+  </configSections>
+  <MSSqlServerSettingsSection>
+    <Columns>
+      <add ColumnName="EventType" DataType="int"/>
+      <add ColumnName="Release" DataType="varchar"/>
+    </Columns>
+  </MSSqlServerSettingsSection>      
+```
 ### Writing properties as columns
 
 This feature will still use all of the default columns and provide additional columns for that can be logged to (be sure to create the extra columns via SQL script first). This gives the flexibility to use as many extra columns as needed.

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/ColumnCollection.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/ColumnCollection.cs
@@ -1,0 +1,32 @@
+﻿
+
+namespace Serilog.Configuration
+{
+    using System;
+    using System.Configuration;
+
+    /// <summary>
+    /// Collection of configuration items for use in generating DataColumn[]
+    /// </summary>
+    public class ColumnCollection : ConfigurationElementCollection
+    {
+        /// <summary>
+        /// Create new element
+        /// </summary>
+        /// <returns>new ColumnConfig instance</returns>
+        protected override ConfigurationElement CreateNewElement()
+        {
+            return new ColumnConfig();
+        }
+
+        /// <summary>
+        /// Fetch Key for the Element
+        /// </summary>
+        /// <param name="element"></param>
+        /// <returns>ColumnName</returns>
+        protected override object GetElementKey(ConfigurationElement element)
+        {
+            return ((ColumnConfig)element).ColumnName;
+        }
+    }
+}

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/ColumnConfig.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/ColumnConfig.cs
@@ -1,0 +1,50 @@
+﻿
+
+namespace Serilog.Configuration
+{
+    using System;
+    using System.Configuration;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public class ColumnConfig : ConfigurationElement
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public ColumnConfig() { }
+
+        /// <summary>
+        /// Create a new instance from key/value pair
+        /// </summary>
+        /// <param name="columnName">Column name in SQL Server</param>
+        /// <param name="dataType">Data type in SQL Server</param>
+        public ColumnConfig(string columnName, string dataType)
+        {
+            ColumnName = columnName;
+            DataType = dataType;
+        }
+
+        /// <summary>
+        /// Name of the Column as it exists in SQL Server
+        /// </summary>
+        [ConfigurationProperty("ColumnName", IsRequired = true, IsKey = true)]
+        public string ColumnName
+        {
+            get { return (string)this["ColumnName"]; }
+            set { this["ColumnName"] = value; }
+        }
+
+        /// <summary>
+        /// Type of column as it exists in SQL Server
+        /// </summary>
+        [ConfigurationProperty("DataType", IsRequired = true, IsKey = false, DefaultValue ="varchar")]
+        [RegexStringValidator("(bigint)|(bit)|(char)|(date)|(datetime)|(datetime2)|(decimal)|(float)|(int)|(money)|(nchar)|(ntext)|(numeric)|(nvarchar)|(real)|(smalldatetime)|(smallint)|(smallmoney)|(text)|(time)|(uniqueidentifier)|(varchar)")]
+        public string DataType
+        {
+            get { return (string)this["DataType"]; }
+            set { this["DataType"] = value; }
+        }
+    }
+}

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/MSSqlServerConfigurationSection.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/MSSqlServerConfigurationSection.cs
@@ -1,0 +1,42 @@
+﻿
+namespace Serilog.Configuration
+{
+    using System;
+    using System.Configuration;
+
+    /// <summary>
+    /// Settings configuration for defining DataColumns collection
+    /// </summary>
+    public class MSSqlServerConfigurationSection : ConfigurationSection
+    {
+        private static MSSqlServerConfigurationSection settings =
+            ConfigurationManager.GetSection("MSSqlServerSettings") as MSSqlServerConfigurationSection;
+
+        /// <summary>
+        /// Access to the settings stored in the config file
+        /// </summary>
+        public static MSSqlServerConfigurationSection Settings
+        {
+            get
+            {
+                return settings;
+            }
+        }
+
+        /// <summary>
+        /// Columns in the database to write data into
+        /// </summary>
+        [ConfigurationProperty("Columns", IsDefaultCollection = false)]
+        [ConfigurationCollection(typeof(ColumnCollection),
+            AddItemName = "add",
+            ClearItemsName = "clear",
+            RemoveItemName = "remove")]
+        public ColumnCollection Columns
+        {
+            get
+            {
+                return (ColumnCollection)base["Columns"];
+            }
+        }
+    }
+}

--- a/src/Serilog.Sinks.MSSqlServer/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/LoggerConfigurationMSSqlServerExtensions.cs
@@ -45,7 +45,7 @@ namespace Serilog
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration MSSqlServer(
             this LoggerSinkConfiguration loggerConfiguration,
-            string connectionString =null, string tableName=null, bool storeProperties = true,
+            string connectionString, string tableName, bool storeProperties = true,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             int batchPostingLimit = MSSqlServerSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
@@ -92,9 +92,6 @@ namespace Serilog
                 Array.Resize<DataColumn>( ref returnColumns, serviceConfigSection.Columns.Count + additionalColumns.Length);
                 i = additionalColumns.Length;
             }
-            //int arraySize = additionalColumns == null ? 0 : additionalColumns.Length;
-            //DataColumn[] returnColumns = new DataColumn[serviceConfigSection.Columns.Count];
-            //int i = 0;
 
             foreach (ColumnConfig c in serviceConfigSection.Columns)
             {

--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -46,13 +46,11 @@
     <AssemblyOriginatorKeyFile>..\..\assets\Serilog.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+    <Reference Include="Serilog">
       <HintPath>..\..\packages\Serilog.1.5.7\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+    <Reference Include="Serilog.FullNetFx">
       <HintPath>..\..\packages\Serilog.1.5.7\lib\net45\Serilog.FullNetFx.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -46,14 +46,17 @@
     <AssemblyOriginatorKeyFile>..\..\assets\Serilog.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Serilog">
-      <HintPath>..\..\packages\Serilog.1.5.7\lib\net45\Serilog.dll</HintPath>
+    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\SearsHomeProVSO\Logging Framework\packages\Serilog.1.5.7\lib\net45\Serilog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog.FullNetFx">
-      <HintPath>..\..\packages\Serilog.1.5.7\lib\net45\Serilog.FullNetFx.dll</HintPath>
+    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\SearsHomeProVSO\Logging Framework\packages\Serilog.1.5.7\lib\net45\Serilog.FullNetFx.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
@@ -61,6 +64,9 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Configuration\ColumnCollection.cs" />
+    <Compile Include="Configuration\ColumnConfig.cs" />
+    <Compile Include="Configuration\MSSqlServerConfigurationSection.cs" />
     <Compile Include="LoggerConfigurationMSSqlServerExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\..\assets\CommonAssemblyInfo.cs">

--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -47,11 +47,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\SearsHomeProVSO\Logging Framework\packages\Serilog.1.5.7\lib\net45\Serilog.dll</HintPath>
+      <HintPath>..\..\packages\Serilog.1.5.7\lib\net45\Serilog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\SearsHomeProVSO\Logging Framework\packages\Serilog.1.5.7\lib\net45\Serilog.FullNetFx.dll</HintPath>
+      <HintPath>..\..\packages\Serilog.1.5.7\lib\net45\Serilog.FullNetFx.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />


### PR DESCRIPTION
Added ability to configure SQL Data Columns via config file instead of via code only. This can be helpful in moving between environments, toggling columns on/off between prod/dev. The config is done via a custom configuration section, something the core Serilog project has worked to avoid. Currently handles merging in configured and coded data columns. Limitation of current MSSqlServerSink using Bulk Load leads to a failure if columns don't match exactly. Next step is to fix that in the Bulk Load code (note: this is a limitation even of using coded data columns in `master` and will be proposed separately from this feature).