### PR TITLE
Save logevent as JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,5 @@ var log = new LoggerConfiguration()
     .CreateLogger();
 ```
 The log event properties `User` and `Other` will now be placed in the corresponding column upon logging. The property name must match a column name in your table.
+
+By default the additional properties will still be included in the XML data saved to the Properties column (assuming that is not disabled). That's consistent with the idea behind structured logging, and makes it easier to convert the log data to another (NoSql) storage platform later if desired.  However, if the data is to stay in SQL Server, then the additional properties may not need to be saved in both columns and XML, so an option in the sink configuration allows you to exclude those properties from the XML.

--- a/README.md
+++ b/README.md
@@ -16,21 +16,22 @@ var log = new LoggerConfiguration()
 You'll need to create a table like this in your database:
 
 ```
-CREATE TABLE [schema].[tablename] (
-   [Id] [int] IDENTITY(1,1) NOT NULL,
-   [Message] [nvarchar](max) NULL,
-   [MessageTemplate] [nvarchar](max) NULL,
-   [Level] [nvarchar](128) NULL,
-   [TimeStamp] [datetimeoffset](7) NOT NULL,
-   [Exception] [nvarchar](max) NULL,
-   [Properties] [xml] NULL,
-   [LogEvent] [nvarchar](max) NULL,
-   [Host] [nvarchar](255) NULL,
-   [User] [nvarchar](255) NULL,
-   CONSTRAINT [PK_tablename] PRIMARY KEY CLUSTERED (
-      [Id] ASC
-   ) WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) 
-   ON [PRIMARY]
+CREATE TABLE [Logs] (
+
+   [Id] int IDENTITY(1,1) NOT NULL,
+   [Message] nvarchar(max) NULL,
+   [MessageTemplate] nvarchar(max) NULL,
+   [Level] nvarchar(128) NULL,
+   [TimeStamp] datetimeoffset(7) NOT NULL,  -- use datetime for SQL Server pre-2008
+   [Exception] nvarchar(max) NULL,
+   [Properties] xml NULL,
+   [LogEvent] nvarchar(max) NULL
+
+   CONSTRAINT [PK_Logs] 
+     PRIMARY KEY CLUSTERED ([Id] ASC) 
+	 WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) 
+     ON [PRIMARY]
+
 ) ON [PRIMARY];
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,4 +44,14 @@ var log = new LoggerConfiguration()
 ```
 The log event properties `User` and `Other` will now be placed in the corresponding column upon logging. The property name must match a column name in your table.
 
-By default the additional properties will still be included in the XML data saved to the Properties column (assuming that is not disabled). That's consistent with the idea behind structured logging, and makes it easier to convert the log data to another (NoSql) storage platform later if desired.  However, if the data is to stay in SQL Server, then the additional properties may not need to be saved in both columns and XML, so an option in the sink configuration allows you to exclude those properties from the XML.
+#### Excluding redundant properties
+
+By default the additional properties will still be included in the XML data saved to the Properties column (assuming that is not disabled via the storeProperties parameter). That's consistent with the idea behind structured logging, and makes it easier to convert the log data to another (e.g. NoSql) storage platform later if desired.  
+
+However, if the data is to stay in SQL Server, then the additional properties may not need to be saved in both columns and XML.  Use the *excludeAdditionalProperties* parameter in the sink configuration to exclude the redundant properties from the XML.
+
+
+### Saving the Log Event
+
+If desired, the *saveLogEvent* parameter will save the event as JSON to the LogEvent column.  Default is false (leaving the column null).
+

--- a/src/Serilog.Sinks.MSSqlServer/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/LoggerConfigurationMSSqlServerExtensions.cs
@@ -41,7 +41,7 @@ namespace Serilog
         /// <param name="storeTimestampInUtc">Store Timestamp In UTC</param>
         /// <param name="additionalDataColumns">Additional columns for data storage.</param>
         /// <param name="excludeAdditionalProperties">Exclude properties from the Properties column if they are being saved to additional columns.</param>
-        /// <param name="saveLogEvent">Save the entire log event to the LogEvent column (nvarchar) as JSON.</param>
+        /// <param name="storeLogEvent">Save the entire log event to the LogEvent column (nvarchar) as JSON.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration MSSqlServer(
@@ -56,7 +56,7 @@ namespace Serilog
             bool storeTimestampInUtc = false,
             DataColumn[] additionalDataColumns = null,
             bool excludeAdditionalProperties = false,
-            bool saveLogEvent = false
+            bool storeLogEvent = true
             )
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
@@ -74,7 +74,7 @@ namespace Serilog
                     storeTimestampInUtc,
                     additionalDataColumns,
                     excludeAdditionalProperties,
-                    saveLogEvent
+                    storeLogEvent
                     ),
                 restrictedToMinimumLevel);
         }

--- a/src/Serilog.Sinks.MSSqlServer/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/LoggerConfigurationMSSqlServerExtensions.cs
@@ -40,24 +40,39 @@ namespace Serilog
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="storeTimestampInUtc">Store Timestamp In UTC</param>
         /// <param name="additionalDataColumns">Additional columns for data storage.</param>
+        /// <param name="excludeAdditionalColumnsFromProperties">Exclude properties from the Properties column if they are being saved to additional columns.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration MSSqlServer(
             this LoggerSinkConfiguration loggerConfiguration,
-            string connectionString, string tableName, bool storeProperties = true,
+            string connectionString,
+            string tableName,
+            bool storeProperties = true,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             int batchPostingLimit = MSSqlServerSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
             bool storeTimestampInUtc = false,
-            DataColumn[] additionalDataColumns = null)
+            DataColumn[] additionalDataColumns = null,
+            bool excludeAdditionalColumnsFromProperties = false
+            )
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
 
             var defaultedPeriod = period ?? MSSqlServerSink.DefaultPeriod;
 
             return loggerConfiguration.Sink(
-                new MSSqlServerSink(connectionString, tableName, storeProperties, batchPostingLimit, defaultedPeriod, formatProvider, storeTimestampInUtc, additionalDataColumns),
+                new MSSqlServerSink(
+                    connectionString,
+                    tableName,
+                    storeProperties,
+                    batchPostingLimit,
+                    defaultedPeriod,
+                    formatProvider,
+                    storeTimestampInUtc,
+                    additionalDataColumns,
+                    excludeAdditionalColumnsFromProperties
+                    ),
                 restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.MSSqlServer/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/LoggerConfigurationMSSqlServerExtensions.cs
@@ -40,7 +40,8 @@ namespace Serilog
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="storeTimestampInUtc">Store Timestamp In UTC</param>
         /// <param name="additionalDataColumns">Additional columns for data storage.</param>
-        /// <param name="excludeAdditionalColumnsFromProperties">Exclude properties from the Properties column if they are being saved to additional columns.</param>
+        /// <param name="excludeAdditionalProperties">Exclude properties from the Properties column if they are being saved to additional columns.</param>
+        /// <param name="saveLogEvent">Save the entire log event to the LogEvent column (nvarchar) as JSON.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration MSSqlServer(
@@ -54,7 +55,8 @@ namespace Serilog
             IFormatProvider formatProvider = null,
             bool storeTimestampInUtc = false,
             DataColumn[] additionalDataColumns = null,
-            bool excludeAdditionalColumnsFromProperties = false
+            bool excludeAdditionalProperties = false,
+            bool saveLogEvent = false
             )
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
@@ -71,7 +73,8 @@ namespace Serilog
                     formatProvider,
                     storeTimestampInUtc,
                     additionalDataColumns,
-                    excludeAdditionalColumnsFromProperties
+                    excludeAdditionalProperties,
+                    saveLogEvent
                     ),
                 restrictedToMinimumLevel);
         }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -55,7 +55,7 @@ namespace Serilog.Sinks.MSSqlServer
         private readonly bool _excludeAdditionalProperties;
         private readonly HashSet<string> _additionalDataColumnNames;
 
-        private readonly bool _saveLogEvent;
+        private readonly bool _storeLogEvent;
         private readonly JsonFormatter _jsonFormatter;
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace Serilog.Sinks.MSSqlServer
         /// <param name="storeTimestampInUtc">Store Timestamp In UTC</param>
         /// <param name="additionalDataColumns">Additional columns for data storage.</param>
         /// <param name="excludeAdditionalProperties">Exclude properties from the Properties column if they are being saved to additional columns.</param>
-        /// <param name="saveLogEvent">Save the entire log event to the LogEvent column (nvarchar) as JSON.</param>
+        /// <param name="storeLogEvent">Save the entire log event to the LogEvent column (nvarchar) as JSON.</param>
         public MSSqlServerSink(
             string connectionString,
             string tableName,
@@ -81,7 +81,7 @@ namespace Serilog.Sinks.MSSqlServer
             bool storeTimestampInUtc,
             DataColumn[] additionalDataColumns = null,
             bool excludeAdditionalProperties = false,
-            bool saveLogEvent = false
+            bool storeLogEvent = true
             )
             : base(batchPostingLimit, period)
         {
@@ -101,8 +101,8 @@ namespace Serilog.Sinks.MSSqlServer
                 _additionalDataColumnNames = new HashSet<string>(_additionalDataColumns.Select(c => c.ColumnName), StringComparer.OrdinalIgnoreCase);
             _excludeAdditionalProperties = excludeAdditionalProperties;
 
-            _saveLogEvent = saveLogEvent;
-            if (_saveLogEvent)
+            _storeLogEvent = storeLogEvent;
+            if (_storeLogEvent)
                 _jsonFormatter = new JsonFormatter(formatProvider: formatProvider);
 
             // Prepare the data table
@@ -228,7 +228,7 @@ namespace Serilog.Sinks.MSSqlServer
                 if (_includeProperties)
                     row["Properties"] = ConvertPropertiesToXmlStructure(logEvent.Properties);
 
-                if (_saveLogEvent)
+                if (_storeLogEvent)
                     row["LogEvent"] = LogEventToJson(logEvent);
 
                 if (_additionalDataColumns != null)


### PR DESCRIPTION
- Fixes a bug where properties with the same name (key) as a column would overwrite the column value.
- Adds option to exclude properties from the Properties xml column if they are being saved as additional columns.
- Adds option to save the log event JSON to new LogEvent nvarchar(max) column.
