### PR TITLE
Added new feature to auto create SQL table if parameter supplied. By default this parameter is false.

### DIFF
--- a/src/Serilog.Sinks.MSSqlServer/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/LoggerConfigurationMSSqlServerExtensions.cs
@@ -25,24 +25,25 @@ namespace Serilog
     /// </summary>
     public static class LoggerConfigurationMSSqlServerExtensions
     {
-        /// <summary>
-        /// Adds a sink that writes log events to a table in a MSSqlServer database.
-        /// Create a database and execute the table creation script found here
-        /// https://gist.github.com/mivano/10429656
-        /// </summary>
-        /// <param name="loggerConfiguration">The logger configuration.</param>
-        /// <param name="connectionString">The connection string to the database where to store the events.</param>
-        /// <param name="tableName">Name of the table to store the events in.</param>
-        /// <param name="storeProperties">Indicates if the additional properties need to be stored as well.</param>
-        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
-        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
-        /// <param name="period">The time to wait between checking for event batches.</param>
-        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="storeTimestampInUtc">Store Timestamp In UTC</param>
-        /// <param name="additionalDataColumns">Additional columns for data storage.</param>
-        /// <returns>Logger configuration, allowing configuration to continue.</returns>
-        /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
-        public static LoggerConfiguration MSSqlServer(
+		/// <summary>
+		/// Adds a sink that writes log events to a table in a MSSqlServer database.
+		/// Create a database and execute the table creation script found here
+		/// https://gist.github.com/mivano/10429656
+		/// </summary>
+		/// <param name="loggerConfiguration">The logger configuration.</param>
+		/// <param name="connectionString">The connection string to the database where to store the events.</param>
+		/// <param name="tableName">Name of the table to store the events in.</param>
+		/// <param name="storeProperties">Indicates if the additional properties need to be stored as well.</param>
+		/// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+		/// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
+		/// <param name="period">The time to wait between checking for event batches.</param>
+		/// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+		/// <param name="storeTimestampInUtc">Store Timestamp In UTC</param>
+		/// <param name="additionalDataColumns">Additional columns for data storage.</param>
+		/// <param name="autoCreateSqlTable">Create log table with the provided name on destination sql server.</param>
+		/// <returns>Logger configuration, allowing configuration to continue.</returns>
+		/// <exception cref="ArgumentNullException">A required parameter is null.</exception>
+		public static LoggerConfiguration MSSqlServer(
             this LoggerSinkConfiguration loggerConfiguration,
             string connectionString, string tableName, bool storeProperties = true,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
@@ -50,14 +51,15 @@ namespace Serilog
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
             bool storeTimestampInUtc = false,
-            DataColumn[] additionalDataColumns = null)
+            DataColumn[] additionalDataColumns = null,
+			bool autoCreateSqlTable = false)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
 
             var defaultedPeriod = period ?? MSSqlServerSink.DefaultPeriod;
 
             return loggerConfiguration.Sink(
-                new MSSqlServerSink(connectionString, tableName, storeProperties, batchPostingLimit, defaultedPeriod, formatProvider, storeTimestampInUtc, additionalDataColumns),
+                new MSSqlServerSink(connectionString, tableName, storeProperties, batchPostingLimit, defaultedPeriod, formatProvider, storeTimestampInUtc, additionalDataColumns, autoCreateSqlTable),
                 restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -46,11 +46,13 @@
     <AssemblyOriginatorKeyFile>..\..\assets\Serilog.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Serilog">
-      <HintPath>..\..\packages\Serilog.1.5.7\lib\net45\Serilog.dll</HintPath>
+    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog.FullNetFx">
-      <HintPath>..\..\packages\Serilog.1.5.7\lib\net45\Serilog.FullNetFx.dll</HintPath>
+    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.FullNetFx.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -67,6 +69,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Sinks\MSSqlServer\MSSqlServerSink.cs" />
+    <Compile Include="Sinks\MSSqlServer\SqlTableCreator.cs" />
     <Compile Include="Sinks\MSSqlServer\XmlPropertyFormatter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -17,10 +17,13 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlClient;
 using System.Data.SqlTypes;
+using System.Diagnostics;
+using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
+using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Sinks.PeriodicBatching;
 namespace Serilog.Sinks.MSSqlServer
@@ -91,10 +94,11 @@ namespace Serilog.Sinks.MSSqlServer
 				{
 					SqlTableCreator tableCreator = new SqlTableCreator(connectionString);
 					tableCreator.CreateTable(_eventsTable);
+					throw  new Exception("Test exception");
 				}
-				catch (Exception)
-				{
-					//ignore the error and allow users to keep logging with other concurrent logging method they are using.
+				catch (Exception ex)
+				{					
+					SelfLog.WriteLine("Exception {0} caught while creating table {1} to the database specified in the Connection string.", (object)ex, (object)tableName);					
 				}
 				
 			}

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -16,245 +16,261 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlClient;
+using System.Data.SqlTypes;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml;
 using Serilog.Events;
 using Serilog.Sinks.PeriodicBatching;
-
 namespace Serilog.Sinks.MSSqlServer
 {
-    /// <summary>
-    ///     Writes log events as rows in a table of MSSqlServer database.
-    /// </summary>
-    public class MSSqlServerSink : PeriodicBatchingSink
-    {
-        /// <summary>
-        ///     A reasonable default for the number of events posted in
-        ///     each batch.
-        /// </summary>
-        public const int DefaultBatchPostingLimit = 50;
+	/// <summary>
+	///     Writes log events as rows in a table of MSSqlServer database.
+	/// </summary>
+	public class MSSqlServerSink : PeriodicBatchingSink
+	{
+		/// <summary>
+		///     A reasonable default for the number of events posted in
+		///     each batch.
+		/// </summary>
+		public const int DefaultBatchPostingLimit = 50;
 
-        /// <summary>
-        ///     A reasonable default time to wait between checking for event batches.
-        /// </summary>
-        public static readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(5);
+		/// <summary>
+		///     A reasonable default time to wait between checking for event batches.
+		/// </summary>
+		public static readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(5);
 
-        readonly string _connectionString;
+		readonly string _connectionString;
 
-        readonly DataTable _eventsTable;
-        readonly IFormatProvider _formatProvider;
-        readonly bool _includeProperties;
-        readonly string _tableName;
-        readonly CancellationTokenSource _token = new CancellationTokenSource();
-        readonly bool _storeTimestampInUtc;
+		readonly DataTable _eventsTable;
+		readonly IFormatProvider _formatProvider;
+		readonly bool _includeProperties;
+		readonly string _tableName;
+		readonly CancellationTokenSource _token = new CancellationTokenSource();
+		readonly bool _storeTimestampInUtc;
 
-        private DataColumn[] _additionalDataColumns;
+		private DataColumn[] _additionalDataColumns;
 
-        /// <summary>
-        ///     Construct a sink posting to the specified database.
-        /// </summary>
-        /// <param name="connectionString">Connection string to access the database.</param>
-        /// <param name="tableName">Name of the table to store the data in.</param>
-        /// <param name="includeProperties">Specifies if the properties need to be saved as well.</param>
-        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
-        /// <param name="period">The time to wait between checking for event batches.</param>
-        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="storeTimestampInUtc">Store Timestamp In UTC</param>
-        /// <param name="additionalDataColumns">Additional columns for data storage.</param>
-        public MSSqlServerSink(string connectionString, string tableName, bool includeProperties, int batchPostingLimit,
-            TimeSpan period, IFormatProvider formatProvider, bool storeTimestampInUtc, DataColumn[] additionalDataColumns = null )
-            : base(batchPostingLimit, period)
-        {
-            if (string.IsNullOrWhiteSpace(connectionString))
-                throw new ArgumentNullException("connectionString");
+		/// <summary>
+		///     Construct a sink posting to the specified database.
+		/// </summary>
+		/// <param name="connectionString">Connection string to access the database.</param>
+		/// <param name="tableName">Name of the table to store the data in.</param>
+		/// <param name="includeProperties">Specifies if the properties need to be saved as well.</param>
+		/// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
+		/// <param name="period">The time to wait between checking for event batches.</param>
+		/// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+		/// <param name="storeTimestampInUtc">Store Timestamp In UTC</param>
+		/// <param name="additionalDataColumns">Additional columns for data storage.</param>
+		/// <param name="autoCreateSqlTable">Create log table with the provided name on destination sql server.</param>
+		public MSSqlServerSink(string connectionString, string tableName, bool includeProperties, int batchPostingLimit,
+			TimeSpan period, IFormatProvider formatProvider, bool storeTimestampInUtc, DataColumn[] additionalDataColumns = null,
+			bool autoCreateSqlTable = false)
+			: base(batchPostingLimit, period)
+		{
+			if (string.IsNullOrWhiteSpace(connectionString))
+				throw new ArgumentNullException("connectionString");
 
-            if (string.IsNullOrWhiteSpace(tableName))
-                throw new ArgumentNullException("tableName");
+			if (string.IsNullOrWhiteSpace(tableName))
+				throw new ArgumentNullException("tableName");
 
+			_connectionString = connectionString;
+			_tableName = tableName;
+			_includeProperties = includeProperties;
+			_formatProvider = formatProvider;
+			_storeTimestampInUtc = storeTimestampInUtc;
+			_additionalDataColumns = additionalDataColumns;
 
-            _connectionString = connectionString;
-            _tableName = tableName;
-            _includeProperties = includeProperties;
-            _formatProvider = formatProvider;
-            _storeTimestampInUtc = storeTimestampInUtc;
-            _additionalDataColumns = additionalDataColumns;
+			// Prepare the data table
+			_eventsTable = CreateDataTable();
 
-            // Prepare the data table
-            _eventsTable = CreateDataTable();
-        }
+			if (autoCreateSqlTable)
+			{
+				SqlTableCreator tableCreator = new SqlTableCreator(connectionString);
+				tableCreator.CreateTable(_eventsTable);
+			}
+		}
 
-        /// <summary>
-        ///     Emit a batch of log events, running asynchronously.
-        /// </summary>
-        /// <param name="events">The events to emit.</param>
-        /// <remarks>
-        ///     Override either <see cref="PeriodicBatchingSink.EmitBatch" /> or <see cref="PeriodicBatchingSink.EmitBatchAsync" />
-        ///     ,
-        ///     not both.
-        /// </remarks>
-        protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)
-        {
-            // Copy the events to the data table
-            FillDataTable(events);
+		/// <summary>
+		///     Emit a batch of log events, running asynchronously.
+		/// </summary>
+		/// <param name="events">The events to emit.</param>
+		/// <remarks>
+		///     Override either <see cref="PeriodicBatchingSink.EmitBatch" /> or <see cref="PeriodicBatchingSink.EmitBatchAsync" />
+		///     ,
+		///     not both.
+		/// </remarks>
+		protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)
+		{
+			// Copy the events to the data table
+			FillDataTable(events);
 
-            using (var cn = new SqlConnection(_connectionString))
-            {
-                await cn.OpenAsync(_token.Token);
-                using (var copy = new SqlBulkCopy(cn))
-                {
-                    copy.DestinationTableName = _tableName;
-                    await copy.WriteToServerAsync(_eventsTable, _token.Token);
+			using (var cn = new SqlConnection(_connectionString))
+			{
+				await cn.OpenAsync(_token.Token);
+				using (var copy = new SqlBulkCopy(cn))
+				{
+					copy.DestinationTableName = _tableName;
+					await copy.WriteToServerAsync(_eventsTable, _token.Token);
 
-                    // Processed the items, clear for the next run
-                    _eventsTable.Clear();
-                }
-            }
-        }
+					// Processed the items, clear for the next run
+					_eventsTable.Clear();
+				}
+			}
+		}
 
-        DataTable CreateDataTable()
-        {
-            var eventsTable = new DataTable(_tableName);
+		DataTable CreateDataTable()
+		{			
+			var eventsTable = new DataTable(_tableName);
 
-            var id = new DataColumn
-            {
-                DataType = Type.GetType("System.Int32"),
-                ColumnName = "Id",
-                AutoIncrement = true
-            };
-            eventsTable.Columns.Add(id);
+			var id = new DataColumn
+			{
+				DataType = Type.GetType("System.Int32"),
+				ColumnName = "Id",
+				AutoIncrement = true
+			};
+			eventsTable.Columns.Add(id);
 
-            var message = new DataColumn
-            {
-                DataType = Type.GetType("System.String"),
-                ColumnName = "Message"
-            };
-            eventsTable.Columns.Add(message);
+			var message = new DataColumn
+			{ 
+				DataType = typeof(string),
+				MaxLength = -1,
+				ColumnName = "Message"
+			};
+			eventsTable.Columns.Add(message);
 
-            var messageTemplate = new DataColumn
-            {
-                DataType = Type.GetType("System.String"),
-                ColumnName = "MessageTemplate"
-            };
-            eventsTable.Columns.Add(messageTemplate);
+			var messageTemplate = new DataColumn
+			{
+				DataType = typeof(string),
+				MaxLength = -1,
+				ColumnName = "MessageTemplate",
 
-            var level = new DataColumn
-            {
-                DataType = Type.GetType("System.String"),
-                ColumnName = "Level"
-            };
-            eventsTable.Columns.Add(level);
+			};
+			eventsTable.Columns.Add(messageTemplate);
 
-            var timestamp = new DataColumn
-            {
-                DataType = Type.GetType("System.DateTime"),
-                ColumnName = "TimeStamp"
-            };
-            eventsTable.Columns.Add(timestamp);
+			var level = new DataColumn
+			{
+				DataType = typeof(string),
+				MaxLength = 128,
+				ColumnName = "Level"
+			};
+			eventsTable.Columns.Add(level);
 
-            var exception = new DataColumn
-            {
-                DataType = Type.GetType("System.String"),
-                ColumnName = "Exception"
-            };
-            eventsTable.Columns.Add(exception);
+			var timestamp = new DataColumn
+			{
+				DataType = Type.GetType("System.DateTime"),
+				ColumnName = "TimeStamp",
+				AllowDBNull = false
+			};
+			eventsTable.Columns.Add(timestamp);
 
-            var props = new DataColumn
-            {
-                DataType = Type.GetType("System.String"),
-                ColumnName = "Properties"
-            };
-            eventsTable.Columns.Add(props);
+			var exception = new DataColumn
+			{
+				DataType = typeof(string),
+				MaxLength = -1,
+				ColumnName = "Exception"
+			};
+			eventsTable.Columns.Add(exception);
 
-            if ( _additionalDataColumns != null )
-            {
-                eventsTable.Columns.AddRange(_additionalDataColumns);
-            }
+			var props = new DataColumn
+			{
+				DataType = typeof(XmlElement),
+				MaxLength = -1,
+				ColumnName = "Properties",
+				ColumnMapping = MappingType.Element
+			};
+			eventsTable.Columns.Add(props);
 
-            // Create an array for DataColumn objects.
-            var keys = new DataColumn[1];
-            keys[0] = id;
-            eventsTable.PrimaryKey = keys;
+			if (_additionalDataColumns != null)
+			{
+				eventsTable.Columns.AddRange(_additionalDataColumns);
+			}
 
-            return eventsTable;
-        }
+			// Create an array for DataColumn objects.
+			var keys = new DataColumn[1];
+			keys[0] = id;
+			eventsTable.PrimaryKey = keys;
 
-     void FillDataTable(IEnumerable<LogEvent> events)
-        {
-            // Add the new rows to the collection. 
-            foreach (var logEvent in events)
-            {
-                var row = _eventsTable.NewRow();
-                row["Message"] = logEvent.RenderMessage(_formatProvider);
-                row["MessageTemplate"] = logEvent.MessageTemplate;
-                row["Level"] = logEvent.Level;
-                row["TimeStamp"] = (_storeTimestampInUtc) ? logEvent.Timestamp.DateTime.ToUniversalTime() 
-                                                          : logEvent.Timestamp.DateTime;
-                row["Exception"] = logEvent.Exception != null ? logEvent.Exception.ToString() : null;
+			return eventsTable;
+		}
 
-                if (_includeProperties)
-                {
-                    row["Properties"] = ConvertPropertiesToXmlStructure(logEvent.Properties);
-                }
-                if ( _additionalDataColumns != null )
-                {
-                    ConvertPropertiesToColumn( row, logEvent.Properties );
-                }
+		void FillDataTable(IEnumerable<LogEvent> events)
+		{
+			// Add the new rows to the collection. 
+			foreach (var logEvent in events)
+			{
+				var row = _eventsTable.NewRow();
+				row["Message"] = logEvent.RenderMessage(_formatProvider);
+				row["MessageTemplate"] = logEvent.MessageTemplate;
+				row["Level"] = logEvent.Level;
+				row["TimeStamp"] = (_storeTimestampInUtc) ? logEvent.Timestamp.DateTime.ToUniversalTime()
+														  : logEvent.Timestamp.DateTime;
+				row["Exception"] = logEvent.Exception != null ? logEvent.Exception.ToString() : null;
 
-                _eventsTable.Rows.Add(row);
-            }
+				if (_includeProperties)
+				{
+					row["Properties"] = ConvertPropertiesToXmlStructure(logEvent.Properties);
+				}
+				if (_additionalDataColumns != null)
+				{
+					ConvertPropertiesToColumn(row, logEvent.Properties);
+				}
 
-            _eventsTable.AcceptChanges();
-        }
+				_eventsTable.Rows.Add(row);
+			}
 
-        static string ConvertPropertiesToXmlStructure(
-            IEnumerable<KeyValuePair<string, LogEventPropertyValue>> properties)
-        {
-            var sb = new StringBuilder();
+			_eventsTable.AcceptChanges();
+		}
 
-            sb.Append("<properties>");
+		static string ConvertPropertiesToXmlStructure(
+			IEnumerable<KeyValuePair<string, LogEventPropertyValue>> properties)
+		{
+			var sb = new StringBuilder();
 
-            foreach (var property in properties)
-            {
-                sb.AppendFormat("<property key='{0}'>{1}</property>", property.Key,
-                    XmlPropertyFormatter.Simplify(property.Value));
-            }
+			sb.Append("<properties>");
 
-            sb.Append("</properties>");
+			foreach (var property in properties)
+			{
+				sb.AppendFormat("<property key='{0}'>{1}</property>", property.Key,
+					XmlPropertyFormatter.Simplify(property.Value));
+			}
 
-            return sb.ToString();
-        }
+			sb.Append("</properties>");
 
-        /// <summary>
-        ///     Mapping values from properties which have a corresponding data row.
-        ///     Matching is done based on Column name and property key
-        /// </summary>
-        /// <param name="row"></param>
-        /// <param name="properties"></param>
-        private void ConvertPropertiesToColumn(
-            DataRow row, IReadOnlyDictionary<string, LogEventPropertyValue> properties)
-        {
-            foreach (var property in properties)
-            {
-                if (row.Table.Columns.Contains(property.Key))
-                {
-                    row[property.Key] = property.Value.ToString();
-                }
-            }
-        }
+			return sb.ToString();
+		}
 
-        /// <summary>
-        ///     Disposes the connection
-        /// </summary>
-        /// <param name="disposing"></param>
-        protected override void Dispose(bool disposing)
-        {
-            _token.Cancel();
+		/// <summary>
+		///     Mapping values from properties which have a corresponding data row.
+		///     Matching is done based on Column name and property key
+		/// </summary>
+		/// <param name="row"></param>
+		/// <param name="properties"></param>
+		private void ConvertPropertiesToColumn(
+			DataRow row, IReadOnlyDictionary<string, LogEventPropertyValue> properties)
+		{
+			foreach (var property in properties)
+			{
+				if (row.Table.Columns.Contains(property.Key))
+				{
+					row[property.Key] = property.Value.ToString();
+				}
+			}
+		}
 
-            if (_eventsTable != null)
-                _eventsTable.Dispose();           
+		/// <summary>
+		///     Disposes the connection
+		/// </summary>
+		/// <param name="disposing"></param>
+		protected override void Dispose(bool disposing)
+		{
+			_token.Cancel();
 
-            base.Dispose(disposing);
-        }
-    }
+			if (_eventsTable != null)
+				_eventsTable.Dispose();
+
+			base.Dispose(disposing);
+		}
+	}
 }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -93,8 +93,7 @@ namespace Serilog.Sinks.MSSqlServer
 				try
 				{
 					SqlTableCreator tableCreator = new SqlTableCreator(connectionString);
-					tableCreator.CreateTable(_eventsTable);
-					throw  new Exception("Test exception");
+					tableCreator.CreateTable(_eventsTable);					
 				}
 				catch (Exception ex)
 				{					

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -87,8 +87,16 @@ namespace Serilog.Sinks.MSSqlServer
 
 			if (autoCreateSqlTable)
 			{
-				SqlTableCreator tableCreator = new SqlTableCreator(connectionString);
-				tableCreator.CreateTable(_eventsTable);
+				try
+				{
+					SqlTableCreator tableCreator = new SqlTableCreator(connectionString);
+					tableCreator.CreateTable(_eventsTable);
+				}
+				catch (Exception)
+				{
+					//ignore the error and allow users to keep logging with other concurrent logging method they are using.
+				}
+				
 			}
 		}
 
@@ -175,10 +183,9 @@ namespace Serilog.Sinks.MSSqlServer
 
 			var props = new DataColumn
 			{
-				DataType = typeof(XmlElement),
+				DataType = typeof(string),
 				MaxLength = -1,
-				ColumnName = "Properties",
-				ColumnMapping = MappingType.Element
+				ColumnName = "Properties",				
 			};
 			eventsTable.Columns.Add(props);
 

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlTableCreator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlTableCreator.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Data;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Text;
+
+namespace Serilog.Sinks.MSSqlServer
+{
+	internal class SqlTableCreator
+	{
+		#region Instance Variables
+		private SqlConnection _connection;
+		public SqlConnection Connection
+		{
+			get { return _connection; }
+			private set
+			{
+				if (value == null) throw new ArgumentNullException(nameof(value));
+				_connection = value;
+			}
+		}
+
+		private SqlTransaction _transaction;
+		public SqlTransaction Transaction
+		{
+			get { return _transaction; }
+			private set
+			{
+				if (value == null) throw new ArgumentNullException(nameof(value));
+				_transaction = value;
+			}
+		}
+
+		private string _tableName;
+		public string DestinationTableName
+		{
+			get { return _tableName; }
+			private set
+			{
+				if (value == null) throw new ArgumentNullException(nameof(value));
+				_tableName = value;
+			}
+		}
+		#endregion
+
+		#region Constructor
+		public SqlTableCreator() { }
+
+		public SqlTableCreator(string connectionSring)
+		{
+			_connection = new SqlConnection(connectionSring);
+			_transaction = null;
+		}
+		public SqlTableCreator(SqlConnection connection) : this(connection, null) { }
+		public SqlTableCreator(SqlConnection connection, SqlTransaction transaction)
+		{
+			_connection = connection;
+			_transaction = transaction;
+		}
+		#endregion
+
+		#region Instance Methods				
+		public object CreateTable(DataTable table)
+		{
+			_tableName = table.TableName;
+			string sql = GetSqlFromDataTable(_tableName, table);
+			
+			SqlCommand cmd = new SqlCommand(sql, _connection);
+
+			cmd.Connection.Open();
+			var result = cmd.ExecuteNonQuery();
+			cmd.Connection.Close();
+			return result;
+		}
+		#endregion
+
+		#region Static Methods
+
+		private static string GetSqlFromDataTable(string tableName, DataTable table)
+		{
+			StringBuilder sql = new StringBuilder();
+			sql.AppendFormat("IF NOT EXISTS (SELECT * FROM sysobjects WHERE name = '{0}' AND xtype = 'U')", tableName);
+			sql.AppendLine(" BEGIN");
+			sql.AppendFormat(" CREATE TABLE [{0}] ( ", tableName);
+
+			// columns
+			int numOfColumns = table.Columns.Count;
+			int i = 1;
+			foreach (DataColumn column in table.Columns)
+			{
+				sql.AppendFormat("[{0}] {1}", column.ColumnName, SqlGetType(column));
+				if (numOfColumns > i)
+					sql.AppendFormat(", ");
+				i++;
+			}
+
+			// primary keys
+			if (table.PrimaryKey.Length > 0)
+			{
+				sql.AppendFormat(" CONSTRAINT [PK_{0}] PRIMARY KEY CLUSTERED (", tableName);
+
+				int numOfKeys = table.PrimaryKey.Length;
+				i = 1;
+				foreach (DataColumn column in table.PrimaryKey)
+				{
+					sql.AppendFormat("[{0}]", column.ColumnName);
+					if (numOfKeys > i)
+						sql.AppendFormat(", ");
+
+					i++;
+				}
+				sql.Append("))");
+			}
+			sql.AppendLine(" END");
+			return sql.ToString();
+		}
+
+		// Return T-SQL data type definition, based on schema definition for a column
+		private static string SqlGetType(object type, int columnSize, int numericPrecision, int numericScale)
+		{
+			switch (type.ToString())
+			{
+				case "System.String":
+					return "NVARCHAR(" + ((columnSize == -1) ? "MAX" : columnSize.ToString()) + ")";
+
+				case "System.Decimal":
+					if (numericScale > 0)
+						return "REAL";
+					if (numericPrecision > 10)
+						return "BIGINT";
+
+					return "INT";
+				case "System.Double":
+				case "System.Single":
+					return "REAL";
+
+				case "System.Int64":
+					return "BIGINT";
+
+				case "System.Int16":
+				case "System.Int32":
+					return "INT";
+
+				case "System.DateTime":
+					return "DATETIME";
+				case "System.Xml.XmlElement":
+					return "XML";
+				default:
+					throw new Exception(type + " not implemented.");
+			}
+		}
+
+		// Overload based on DataColumn from DataTable type
+		private static string SqlGetType(DataColumn column)
+		{
+			return SqlGetType(column.DataType, column.MaxLength, 10, 2);
+		}
+		#endregion
+	}
+}

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlTableCreator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlTableCreator.cs
@@ -25,16 +25,19 @@ namespace Serilog.Sinks.MSSqlServer
 		#region Instance Methods				
 		public object CreateTable(DataTable table)
 		{
-			if (!string.IsNullOrWhiteSpace(_tableName) && !string.IsNullOrWhiteSpace(_connectionSring))
+			if (table != null)
 			{
-				_tableName = table.TableName;
-				using (var conn = new SqlConnection(_connectionSring))
+				if (!string.IsNullOrWhiteSpace(table.TableName) && !string.IsNullOrWhiteSpace(_connectionSring))
 				{
-					string sql = GetSqlFromDataTable(_tableName, table);
-					SqlCommand cmd = new SqlCommand(sql, conn);
+					_tableName = table.TableName;
+					using (var conn = new SqlConnection(_connectionSring))
+					{
+						string sql = GetSqlFromDataTable(_tableName, table);
+						SqlCommand cmd = new SqlCommand(sql, conn);
 
-					conn.Open();
-					return cmd.ExecuteNonQuery();
+						conn.Open();
+						return cmd.ExecuteNonQuery();
+					}
 				}
 			}
 			return 0;

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlTableCreator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlTableCreator.cs
@@ -10,9 +10,7 @@ namespace Serilog.Sinks.MSSqlServer
 	{
 		private readonly string _connectionSring;
 		private string _tableName;
-		
-		
-
+				
 		#region Constructor
 		
 		public SqlTableCreator(string connectionSring)
@@ -59,6 +57,8 @@ namespace Serilog.Sinks.MSSqlServer
 			foreach (DataColumn column in table.Columns)
 			{
 				sql.AppendFormat("[{0}] {1}", column.ColumnName, SqlGetType(column));
+			    if (column.ColumnName.ToUpper().Equals("ID"))
+			        sql.Append(" IDENTITY(1,1) ");
 				if (numOfColumns > i)
 					sql.AppendFormat(", ");
 				i++;

--- a/src/Serilog.Sinks.MSSqlServer/packages.config
+++ b/src/Serilog.Sinks.MSSqlServer/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Serilog" version="1.5.7" targetFramework="net45" />
+  <package id="Serilog" version="1.5.14" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
- Auto create SQL server table instead creating it manually with a separate SQL query.
- A new parameter "autoCreateSqlTable" in the LoggerConfiguration is added and is passed on to MSSqlServerSink() constructor to be used.
- Default value of autoCreateSqlTable parameter is false and the parameter is optional.
- This uses DataTable returned by CreateDataTable() to create a table in the SQL server database.
- This uses Connection String and Tablename parameters to determine the destination and name of the table to create.
- All the string type data tables will be converted to NVARCHAR variables in the SQL table.
- MaxLength property of the DataColumn determines size of the field in the table, ( -1 ) means MAX.