### PR TITLE
Added support for additional columns that are nullable.

### DIFF
--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -24,8 +24,6 @@ using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Formatting.Json;
 using Serilog.Sinks.PeriodicBatching;
-using Serilog.Parsing;
-
 
 namespace Serilog.Sinks.MSSqlServer
 {
@@ -332,8 +330,21 @@ namespace Serilog.Sinks.MSSqlServer
                 var columnName = property.Key;
                 var columnType = row.Table.Columns[columnName].DataType;
                 object conversion;
+
                 var scalarValue = property.Value as ScalarValue;
-                if (scalarValue != null && TryChangeType(scalarValue.Value, columnType, out conversion))
+                if (scalarValue == null)
+                {
+                    row[columnName] = property.Value.ToString();
+                    continue;                    
+                }
+
+                if (scalarValue.Value == null && row.Table.Columns[columnName].AllowDBNull)
+                {
+                    row[columnName] = DBNull.Value;
+                    continue;
+                }
+                
+                if (TryChangeType(scalarValue.Value, columnType, out conversion))
                 {
                     row[columnName] = conversion;
                 }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlTableCreator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlTableCreator.cs
@@ -95,7 +95,11 @@ namespace Serilog.Sinks.MSSqlServer
 	                sqlType = "BIT";
 	                break;
 
-	            case "System.String":
+                case "System.Byte":
+                    sqlType = "TINYINT";
+                    break;
+
+                case "System.String":
 	                sqlType = "NVARCHAR(" + ((columnSize == -1) ? "MAX" : columnSize.ToString()) + ")";
 	                break;
 


### PR DESCRIPTION
Previously, when trying to use an additional column, and the associated property value was null, you could get an exception in the TryChangeType method called from ConvertPropertiesToColumn.
Added code to set the DataRow to DBNull instead in that situation if the column is nullable.