### PR TITLE
Space saving changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The log event JSON can be stored to the LogEvent column. This can be enabled wit
 ### Options for serialization of the Properties column
 
 The serialization of the properties column can be controlled by setting values in the in the *columnOptions.Properties* parameter.
+
 Names of elements can be controlled by the *RootElementName*, *PropertyElementName*, *ItemElementName*, *DictionaryElementName*, *SequenceElementName*, *StructureElementName* and *UsePropertyKeyAsElementName* options.
 The *UsePropertyKeyAsElementName* option, if set to true, will use the property key as the element name instead of "property" for the name with the key as an attribute.
 

--- a/README.md
+++ b/README.md
@@ -96,9 +96,10 @@ However, if the data is to stay in SQL Server, then the additional properties ma
 
 The log event JSON can be stored to the LogEvent column. This can be enabled with the *columnOptions.Store* parameter.
 
-### Options for serialization of the properties column
+### Options for serialization of the Properties column
 
 The serialization of the properties column can be controlled by setting values in the in the *columnOptions.Properties* parameter.
 Names of elements can be controlled by the *RootElementName*, *PropertyElementName*, *ItemElementName*, *DictionaryElementName*, *SequenceElementName*, *StructureElementName* and *UsePropertyKeyAsElementName* options.
 The *UsePropertyKeyAsElementName* option, if set to true, will use the property key as the element name instead of "property" for the name with the key as an attribute.
+
 If *OmitElementIfEmpty* is true then if a property is empty, it will not be serialized.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ CREATE TABLE [Logs] (
 ) ON [PRIMARY];
 ```
 
-If you don't plan on using the Properties or LogEvent columns, you can disable their use with the *storeProperties* and *storeLogEvent* parameters.
+If you don't plan on using one or more columns, you can specify which columns to include in the *columnOptions.Store* parameter.
 
 NOTE Make sure to set up security in such a way that the sink can write to the log table. 
 
@@ -54,14 +54,17 @@ If you are configuring Serilog with the `ReadFrom.AppSettings()` XML configurati
 This feature will still use all of the default columns and provide additional columns for that can be logged to (be sure to create the extra columns via SQL script first). This gives the flexibility to use as many extra columns as needed.
 
 ```csharp
-var dataColumns = new[]
+var columnOptions = new ColumnOptions
+{
+    AdditionalDataColumns = new Collection<DataColumn>
     {
-        new DataColumn { DataType = typeof(string), ColumnName = "User" },
-        new DataColumn { DataType = typeof(string), ColumnName = "Other" },
-    };
-    
+        new DataColumn {DataType = typeof (string), ColumnName = "User"},
+        new DataColumn {DataType = typeof (string), ColumnName = "Other"},
+    }
+};
+
 var log = new LoggerConfiguration()
-    .WriteTo.MSSqlServer(@"Server=.\SQLEXPRESS;Database=LogEvents;Trusted_Connection=True;", "Logs", additionalDataColumns: dataColumns)
+    .WriteTo.MSSqlServer(@"Server=.\SQLEXPRESS;Database=LogEvents;Trusted_Connection=True;", "Logs", columnOptions: columnOptions)
     .CreateLogger();
 ```
 The log event properties `User` and `Other` will now be placed in the corresponding column upon logging. The property name must match a column name in your table.
@@ -85,10 +88,10 @@ If you set the *autoCreateSqlTable* option to true, it will create a table for y
 
 #### Excluding redundant items from the Properties column
 
-By default the additional properties will still be included in the XML data saved to the Properties column (assuming that is not disabled via the storeProperties parameter). That's consistent with the idea behind structured logging, and makes it easier to convert the log data to another (e.g. NoSql) storage platform later if desired.  
+By default the additional properties will still be included in the XML data saved to the Properties column (assuming that is not disabled via the columnOptions.Store parameter). That's consistent with the idea behind structured logging, and makes it easier to convert the log data to another (e.g. NoSql) storage platform later if desired.  
 
-However, if the data is to stay in SQL Server, then the additional properties may not need to be saved in both columns and XML.  Use the *excludeAdditionalProperties* parameter in the sink configuration to exclude the redundant properties from the XML.
+However, if the data is to stay in SQL Server, then the additional properties may not need to be saved in both columns and XML.  Use the *columnOptions.Properties.ExcludeAdditionalProperties* parameter in the sink configuration to exclude the redundant properties from the XML.
 
 ### Saving the Log Event data
 
-The log event JSON can be stored to the LogEvent column. This can be enabled with the *storeLogEvent* parameter.
+The log event JSON can be stored to the LogEvent column. This can be enabled with the *columnOptions.Store* parameter.

--- a/README.md
+++ b/README.md
@@ -95,3 +95,10 @@ However, if the data is to stay in SQL Server, then the additional properties ma
 ### Saving the Log Event data
 
 The log event JSON can be stored to the LogEvent column. This can be enabled with the *columnOptions.Store* parameter.
+
+### Options for serialization of the properties column
+
+The serialization of the properties column can be controlled by setting values in the in the *columnOptions.Properties* parameter.
+Names of elements can be controlled by the *RootElementName*, *PropertyElementName*, *ItemElementName*, *DictionaryElementName*, *SequenceElementName*, *StructureElementName* and *UsePropertyKeyAsElementName* options.
+The *UsePropertyKeyAsElementName* option, if set to true, will use the property key as the element name instead of "property" for the name with the key as an attribute.
+If *OmitElementIfEmpty* is true then if a property is empty, it will not be serialized.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ CREATE TABLE [Logs] (
 ```
 
 If you don't plan on using one or more columns, you can specify which columns to include in the *columnOptions.Store* parameter.
+The Level column should be defined as a TinyInt if the *columnOptions.Level.StoreAsEnum* is set to true.
 
 NOTE Make sure to set up security in such a way that the sink can write to the log table. 
 

--- a/README.md
+++ b/README.md
@@ -103,4 +103,6 @@ The serialization of the properties column can be controlled by setting values i
 Names of elements can be controlled by the *RootElementName*, *PropertyElementName*, *ItemElementName*, *DictionaryElementName*, *SequenceElementName*, *StructureElementName* and *UsePropertyKeyAsElementName* options.
 The *UsePropertyKeyAsElementName* option, if set to true, will use the property key as the element name instead of "property" for the name with the key as an attribute.
 
+If *OmitDictionaryContainerElement*, *OmitSequenceContainerElement* or *OmitStructureContainerElement* are true then the "dictionary", "sequence" or "structure" container elements will be omitted and only child elements are included.
+
 If *OmitElementIfEmpty* is true then if a property is empty, it will not be serialized.

--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -72,8 +72,10 @@
     <Compile Include="..\..\assets\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Sinks\MSSqlServer\ColumnOptions.cs" />
     <Compile Include="Sinks\MSSqlServer\MSSqlServerSink.cs" />
     <Compile Include="Sinks\MSSqlServer\SqlTableCreator.cs" />
+    <Compile Include="Sinks\MSSqlServer\StandardColumn.cs" />
     <Compile Include="Sinks\MSSqlServer\XmlPropertyFormatter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions.cs
@@ -97,6 +97,25 @@ namespace Serilog.Sinks.MSSqlServer
             ///     The name to use for a dictionary element.
             /// </summary>
             public string DictionaryElementName { get; set; }
+            /// <summary>
+            ///     The name to use for an item element.
+            /// </summary>
+            public string ItemElementName { get; set; }
+
+            /// <summary>
+            /// If true and the property value is empty, then don't include the element.
+            /// </summary>
+            public bool OmitElementIfEmpty { get; set; }
+
+            /// <summary>
+            ///     The name to use for a property element.
+            /// </summary>
+            public string PropertyElementName { get; set; }
+
+            /// <summary>
+            ///     The name to use for the root element.
+            /// </summary>
+            public string RootElementName { get; set; }
 
             /// <summary>
             ///     The name to use for a sequence element.
@@ -108,21 +127,6 @@ namespace Serilog.Sinks.MSSqlServer
             /// </summary>
             public string StructureElementName { get; set; }
 
-
-            /// <summary>
-            ///     The name to use for an item element.
-            /// </summary>
-            public string ItemElementName { get; set; }
-
-            /// <summary>
-            ///     The name to use for a property element.
-            /// </summary>
-            public string PropertyElementName { get; set; }
-
-            /// <summary>
-            ///     The name to use for the root element.
-            /// </summary>
-            public string RootElementName { get; set; }
 
             /// <summary>
             ///     If true, will use the property key as the element name.

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions.cs
@@ -103,6 +103,21 @@ namespace Serilog.Sinks.MSSqlServer
             public string ItemElementName { get; set; }
 
             /// <summary>
+            /// If true will omit the "dictionary" container element, and will only include child elements.
+            /// </summary>
+            public bool OmitDictionaryContainerElement { get; set; }
+
+            /// <summary>
+            /// If true will omit the "sequence" container element, and will only include child elements.
+            /// </summary>
+            public bool OmitSequenceContainerElement { get; set; }
+
+            /// <summary>
+            /// If true will omit the "structure" container element, and will only include child elements.
+            /// </summary>
+            public bool OmitStructureContainerElement { get; set; }
+
+            /// <summary>
             /// If true and the property value is empty, then don't include the element.
             /// </summary>
             public bool OmitElementIfEmpty { get; set; }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions.cs
@@ -17,6 +17,8 @@ namespace Serilog.Sinks.MSSqlServer
         /// </summary>
         public ColumnOptions()
         {
+            Level = new LevelColumnOptions();
+
             Properties = new PropertiesColumnOptions();
 
             Store = new Collection<StandardColumn>
@@ -61,14 +63,30 @@ namespace Serilog.Sinks.MSSqlServer
         public ICollection<DataColumn> AdditionalDataColumns { get; set; }
 
         /// <summary>
-        ///     Options for the TimeStamp column.
+        ///     Options for the Level column.
         /// </summary>
-        public TimeStampColumnOptions TimeStamp { get; private set; }
+        public LevelColumnOptions Level { get; private set; }
 
         /// <summary>
         ///     Options for the Properties column.
         /// </summary>
         public PropertiesColumnOptions Properties { get; private set; }
+
+        /// <summary>
+        ///     Options for the TimeStamp column.
+        /// </summary>
+        public TimeStampColumnOptions TimeStamp { get; private set; }
+
+        /// <summary>
+        ///     Options for the Level column.
+        /// </summary>
+        public class LevelColumnOptions
+        {
+            /// <summary>
+            ///     If true will store Level as an enum in a tinyint column as opposed to a string.
+            /// </summary>
+            public bool StoreAsEnum { get; set; }
+        }
 
         /// <summary>
         ///     Options for the Properties column.
@@ -97,28 +115,29 @@ namespace Serilog.Sinks.MSSqlServer
             ///     The name to use for a dictionary element.
             /// </summary>
             public string DictionaryElementName { get; set; }
+
             /// <summary>
             ///     The name to use for an item element.
             /// </summary>
             public string ItemElementName { get; set; }
 
             /// <summary>
-            /// If true will omit the "dictionary" container element, and will only include child elements.
+            ///     If true will omit the "dictionary" container element, and will only include child elements.
             /// </summary>
             public bool OmitDictionaryContainerElement { get; set; }
 
             /// <summary>
-            /// If true will omit the "sequence" container element, and will only include child elements.
+            ///     If true will omit the "sequence" container element, and will only include child elements.
             /// </summary>
             public bool OmitSequenceContainerElement { get; set; }
 
             /// <summary>
-            /// If true will omit the "structure" container element, and will only include child elements.
+            ///     If true will omit the "structure" container element, and will only include child elements.
             /// </summary>
             public bool OmitStructureContainerElement { get; set; }
 
             /// <summary>
-            /// If true and the property value is empty, then don't include the element.
+            ///     If true and the property value is empty, then don't include the element.
             /// </summary>
             public bool OmitElementIfEmpty { get; set; }
 

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Data;
+
+namespace Serilog.Sinks.MSSqlServer
+{
+    /// <summary>
+    ///     Options that pertain to columns
+    /// </summary>
+    public class ColumnOptions
+    {
+        private ICollection<StandardColumn> _store;
+
+        /// <summary>
+        ///     Default constructor.
+        /// </summary>
+        public ColumnOptions()
+        {
+            Properties = new PropertiesColumnOptions();
+
+            Store = new Collection<StandardColumn>
+            {
+                StandardColumn.Message,
+                StandardColumn.MessageTemplate,
+                StandardColumn.Level,
+                StandardColumn.TimeStamp,
+                StandardColumn.Exception,
+                StandardColumn.Properties
+            };
+
+            TimeStamp = new TimeStampColumnOptions();
+        }
+
+        /// <summary>
+        ///     A list of columns that will be stored in the logs table in the database.
+        /// </summary>
+        public ICollection<StandardColumn> Store
+        {
+            get { return _store; }
+            set
+            {
+                if (value == null)
+                {
+                    _store = new Collection<StandardColumn>();
+                    foreach (StandardColumn column in Enum.GetValues(typeof (StandardColumn)))
+                    {
+                        _store.Add(column);
+                    }
+                }
+                else
+                {
+                    _store = value;
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Additional columns for data storage.
+        /// </summary>
+        public ICollection<DataColumn> AdditionalDataColumns { get; set; }
+
+        /// <summary>
+        ///     Options for the TimeStamp column.
+        /// </summary>
+        public TimeStampColumnOptions TimeStamp { get; private set; }
+
+        /// <summary>
+        ///     Options for the Properties column.
+        /// </summary>
+        public PropertiesColumnOptions Properties { get; private set; }
+
+        /// <summary>
+        ///     Options for the Properties column.
+        /// </summary>
+        public class PropertiesColumnOptions
+        {
+            /// <summary>
+            ///     Exclude properties from the Properties column if they are being saved to additional columns.
+            /// </summary>
+            public bool ExcludeAdditionalProperties { get; set; }
+        }
+
+        /// <summary>
+        ///     Options for the TimeStamp column.
+        /// </summary>
+        public class TimeStampColumnOptions
+        {
+            /// <summary>
+            ///     If true, the time is converted to universal time.
+            /// </summary>
+            public bool ConvertToUtc { get; set; }
+        }
+    }
+}

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions.cs
@@ -76,9 +76,58 @@ namespace Serilog.Sinks.MSSqlServer
         public class PropertiesColumnOptions
         {
             /// <summary>
+            ///     Default constructor.
+            /// </summary>
+            public PropertiesColumnOptions()
+            {
+                DictionaryElementName = "dictionary";
+                ItemElementName = "item";
+                PropertyElementName = "property";
+                SequenceElementName = "sequence";
+                StructureElementName = "structure";
+                RootElementName = "properties";
+            }
+
+            /// <summary>
             ///     Exclude properties from the Properties column if they are being saved to additional columns.
             /// </summary>
             public bool ExcludeAdditionalProperties { get; set; }
+
+            /// <summary>
+            ///     The name to use for a dictionary element.
+            /// </summary>
+            public string DictionaryElementName { get; set; }
+
+            /// <summary>
+            ///     The name to use for a sequence element.
+            /// </summary>
+            public string SequenceElementName { get; set; }
+
+            /// <summary>
+            ///     The name to use for a structure element.
+            /// </summary>
+            public string StructureElementName { get; set; }
+
+
+            /// <summary>
+            ///     The name to use for an item element.
+            /// </summary>
+            public string ItemElementName { get; set; }
+
+            /// <summary>
+            ///     The name to use for a property element.
+            /// </summary>
+            public string PropertyElementName { get; set; }
+
+            /// <summary>
+            ///     The name to use for the root element.
+            /// </summary>
+            public string RootElementName { get; set; }
+
+            /// <summary>
+            ///     If true, will use the property key as the element name.
+            /// </summary>
+            public bool UsePropertyKeyAsElementName { get; set; }
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -325,7 +325,7 @@ namespace Serilog.Sinks.MSSqlServer
             {
                 if (options.UsePropertyKeyAsElementName)
                 {
-                    sb.AppendFormat("<{0}>{1}</{0}>", property.Key,
+                    sb.AppendFormat("<{0}>{1}</{0}>", XmlPropertyFormatter.GetValidElementName(property.Key),
                         XmlPropertyFormatter.Simplify(property.Value, options));
                 }
                 else

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -323,17 +323,23 @@ namespace Serilog.Sinks.MSSqlServer
 
             foreach (var property in properties)
             {
+                var value = XmlPropertyFormatter.Simplify(property.Value, options);
+                if (options.OmitElementIfEmpty && string.IsNullOrEmpty(value))
+                {
+                    continue;
+                }
+
                 if (options.UsePropertyKeyAsElementName)
                 {
                     sb.AppendFormat("<{0}>{1}</{0}>", XmlPropertyFormatter.GetValidElementName(property.Key),
-                        XmlPropertyFormatter.Simplify(property.Value, options));
+                        value);
                 }
                 else
                 {
                     sb.AppendFormat("<{0} key='{1}'>{2}</{0}>",
                         options.PropertyElementName,
                         property.Key,
-                        XmlPropertyFormatter.Simplify(property.Value, options));
+                        value);
                 }
             }
 

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -197,10 +197,19 @@ namespace Serilog.Sinks.MSSqlServer
             {
                 var level = new DataColumn
                 {
-                    DataType = typeof (string),
-                    MaxLength = 128,
                     ColumnName = "Level"
                 };
+
+                if (_columnOptions.Level.StoreAsEnum)
+                {
+                    level.DataType = typeof (byte);
+                }
+                else
+                {
+                    level.DataType = typeof (string);
+                    level.MaxLength = 128;
+                }
+
                 eventsTable.Columns.Add(level);
             }
 

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlTableCreator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlTableCreator.cs
@@ -89,7 +89,10 @@ namespace Serilog.Sinks.MSSqlServer
 		{
 			switch (type.ToString())
 			{
-				case "System.String":
+                case "System.Byte":
+                    return "TINYINT";
+
+                case "System.String":
 					return "NVARCHAR(" + ((columnSize == -1) ? "MAX" : columnSize.ToString()) + ")";
 
 				case "System.Decimal":

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/StandardColumn.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/StandardColumn.cs
@@ -1,0 +1,43 @@
+﻿namespace Serilog.Sinks.MSSqlServer
+{
+    /// <summary>
+    ///     List of columns that are available to be written to the database, excluding Id and additional columns.
+    /// </summary>
+    public enum StandardColumn
+    {
+        /// <summary>
+        /// The message rendered with the template given the properties associated with the event.
+        /// </summary>
+        Message,
+
+        /// <summary>
+        /// The message template describing the event.
+        /// </summary>
+        MessageTemplate,
+
+        /// <summary>
+        /// The level of the event.
+        /// </summary>
+        Level,
+
+        /// <summary>
+        /// The time at which the event occurred.
+        /// </summary>
+        TimeStamp,
+
+        /// <summary>
+        /// An exception associated with the event, or null.
+        /// </summary>
+        Exception,
+
+        /// <summary>
+        /// Properties associated with the event, including those presented in MessageTemplate/>.
+        /// </summary>
+        Properties,
+
+        /// <summary>
+        /// A log event.
+        /// </summary>
+        LogEvent
+    }
+}

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/XmlPropertyFormatter.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/XmlPropertyFormatter.cs
@@ -59,7 +59,10 @@ namespace Serilog.Sinks.MSSqlServer
                     if (isEmpty)
                     {
                         isEmpty = false;
-                        sb.AppendFormat("<{0}>", options.DictionaryElementName);
+                        if (!options.OmitDictionaryContainerElement)
+                        {
+                            sb.AppendFormat("<{0}>", options.DictionaryElementName);
+                        }
                     }
 
                     var key = SimplifyScalar(element.Key);
@@ -73,7 +76,7 @@ namespace Serilog.Sinks.MSSqlServer
                     }
                 }
 
-                if (!isEmpty)
+                if (!isEmpty && !options.OmitDictionaryContainerElement)
                 {
                     sb.AppendFormat("</{0}>", options.DictionaryElementName);
                 }
@@ -99,13 +102,16 @@ namespace Serilog.Sinks.MSSqlServer
                     if (isEmpty)
                     {
                         isEmpty = false;
-                        sb.AppendFormat("<{0}>", options.SequenceElementName);
+                        if (!options.OmitSequenceContainerElement)
+                        {
+                            sb.AppendFormat("<{0}>", options.SequenceElementName);
+                        }
                     }
 
                     sb.AppendFormat("<{0}>{1}</{0}>", options.ItemElementName, itemValue);
                 }
 
-                if (!isEmpty)
+                if (!isEmpty && !options.OmitSequenceContainerElement)
                 {
                     sb.AppendFormat("</{0}>", options.SequenceElementName);
                 }
@@ -133,13 +139,16 @@ namespace Serilog.Sinks.MSSqlServer
                     if (isEmpty)
                     {
                         isEmpty = false;
-                        if (options.UsePropertyKeyAsElementName)
+                        if (!options.OmitStructureContainerElement)
                         {
-                            sb.AppendFormat("<{0}>", GetValidElementName(str.TypeTag));
-                        }
-                        else
-                        {
-                            sb.AppendFormat("<{0} type='{1}'>", options.StructureElementName, str.TypeTag);
+                            if (options.UsePropertyKeyAsElementName)
+                            {
+                                sb.AppendFormat("<{0}>", GetValidElementName(str.TypeTag));
+                            }
+                            else
+                            {
+                                sb.AppendFormat("<{0} type='{1}'>", options.StructureElementName, str.TypeTag);
+                            }
                         }
                     }
 
@@ -154,7 +163,7 @@ namespace Serilog.Sinks.MSSqlServer
                     }
                 }
 
-                if (!isEmpty)
+                if (!isEmpty && !options.OmitStructureContainerElement)
                 {
                     if (options.UsePropertyKeyAsElementName)
                     {


### PR DESCRIPTION
The purpose of these changes is to provide options to potentially reduce the amount of space the logs table will take up. The other purpose is provide an alternate method of serialization of the properties column, to facilitate a different readability preference.

This is done by:
* Allowing all columns except for Id to be included or excluded from the logs table.
* Providing alternate serialization of the properties column
    * The standard element names can be configured, so they potentially could use a shorter name.
    * The property key could be used as the element name, which potentially may be shorter.
    * Properties can be omitted if empty.
* Adding an option for the level column to be saved as an Enum, using tinyint as the column's datatype.

Because the amount of parameters for column options was starting to become significant, these parameters were consolidated into a single parameter, using a new ColumnOptions class.