### PR TITLE
Fix StandardColumn enum XML documentation

### DIFF
--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/StandardColumn.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/StandardColumn.cs
@@ -31,7 +31,7 @@
         Exception,
 
         /// <summary>
-        /// Properties associated with the event, including those presented in MessageTemplate/>.
+        /// Properties associated with the event, including those presented in <see cref="MessageTemplate"/>.
         /// </summary>
         Properties,
 


### PR DESCRIPTION
The documentation has `/>` without the opening tag. I'm not sure if it was meant to have a reference or not, but I've added one to match the closing bit, I can just remove the closing tag characters if you don't want it.