### PR TITLE
IdColumnOptions - change Id column name

### DIFF
--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions.cs
@@ -17,6 +17,8 @@ namespace Serilog.Sinks.MSSqlServer
         /// </summary>
         public ColumnOptions()
         {
+            Id = new IdColumnOptions();
+
             Level = new LevelColumnOptions();
 
             Properties = new PropertiesColumnOptions();
@@ -65,6 +67,11 @@ namespace Serilog.Sinks.MSSqlServer
         public ICollection<DataColumn> AdditionalDataColumns { get; set; }
 
         /// <summary>
+        ///     Options for the Id column.
+        /// </summary>
+        public IdColumnOptions Id { get; private set; }
+
+        /// <summary>
         ///     Options for the Level column.
         /// </summary>
         public LevelColumnOptions Level { get; private set; }
@@ -83,6 +90,17 @@ namespace Serilog.Sinks.MSSqlServer
         ///     Options for the LogEvent column.
         /// </summary>
         public LogEventColumnOptions LogEvent { get; private set; }
+
+        /// <summary>
+        ///     Options for the Id column.
+        /// </summary>
+        public class IdColumnOptions
+        {
+            /// <summary>
+            ///     The name of the Id column. "Id" is used if not set.
+            /// </summary>
+            public string ColumnName { get; set; }
+        }
 
         /// <summary>
         ///     Options for the Level column.

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -163,7 +163,7 @@ namespace Serilog.Sinks.MSSqlServer
             var id = new DataColumn
             {
                 DataType = Type.GetType("System.Int32"),
-                ColumnName = "Id",
+                ColumnName = !string.IsNullOrWhiteSpace(_columnOptions.Id.ColumnName) ? _columnOptions.Id.ColumnName : "Id",
                 AutoIncrement = true
             };
             eventsTable.Columns.Add(id);


### PR DESCRIPTION
I've added an IdColumnOptions class to ColumnOptions. This includes the property "ColumnName", allowing you to change the name of the Id column.

This is so the sink can work with databases with specific entity Id naming conventions (e.g. where "MyEntity" is required to have an Id column named "MyEntityId").

If unused, the column name continues to be "Id".

I haven't tested this with the Automatic table creation.

Let me know what you think!