### PR TITLE
Demostrates a work-around for issue #31

### DIFF
--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -436,12 +436,12 @@ namespace Serilog.Sinks.MSSqlServer
         /// <param name="disposing"></param>
         protected override void Dispose(bool disposing)
         {
-            _token.Cancel();
-
             if (_eventsTable != null)
                 _eventsTable.Dispose();
 
             base.Dispose(disposing);
+
+            _token.Cancel();
         }
     }
 }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -48,7 +48,6 @@ namespace Serilog.Sinks.MSSqlServer
         readonly DataTable _eventsTable;
         readonly IFormatProvider _formatProvider;
         readonly string _tableName;
-        readonly CancellationTokenSource _token = new CancellationTokenSource();
         private readonly ColumnOptions _columnOptions;
 
         private readonly HashSet<string> _additionalDataColumnNames;
@@ -129,7 +128,7 @@ namespace Serilog.Sinks.MSSqlServer
             {
                 using (var cn = new SqlConnection(_connectionString))
                 {
-                    await cn.OpenAsync(_token.Token).ConfigureAwait(false);
+                    await cn.OpenAsync().ConfigureAwait(false);
                     using (var copy = new SqlBulkCopy(cn))
                     {
                         copy.DestinationTableName = _tableName;
@@ -140,9 +139,8 @@ namespace Serilog.Sinks.MSSqlServer
                             copy.ColumnMappings.Add(mapping);
                         }
 
-                        await copy.WriteToServerAsync(_eventsTable, _token.Token).ConfigureAwait(false);
+                        await copy.WriteToServerAsync(_eventsTable).ConfigureAwait(false);
                     }
-
                 }
             }
             catch (Exception ex)
@@ -440,8 +438,6 @@ namespace Serilog.Sinks.MSSqlServer
                 _eventsTable.Dispose();
 
             base.Dispose(disposing);
-
-            _token.Cancel();
         }
     }
 }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/project.lock.json
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/project.lock.json
@@ -362,7 +362,7 @@
           "lib/net35/xunit.runner.utility.desktop.dll": {}
         }
       },
-      "Serilog.Sinks.MSSqlServer/4.0.0": {
+      "Serilog.Sinks.MSSqlServer/4.1.0": {
         "type": "project",
         "framework": ".NETFramework,Version=v4.5",
         "dependencies": {
@@ -708,7 +708,7 @@
           "lib/net35/xunit.runner.utility.desktop.dll": {}
         }
       },
-      "Serilog.Sinks.MSSqlServer/4.0.0": {
+      "Serilog.Sinks.MSSqlServer/4.1.0": {
         "type": "project",
         "framework": ".NETFramework,Version=v4.5",
         "dependencies": {
@@ -1166,7 +1166,7 @@
         "xunit.runner.utility.nuspec"
       ]
     },
-    "Serilog.Sinks.MSSqlServer/4.0.0": {
+    "Serilog.Sinks.MSSqlServer/4.1.0": {
       "type": "project",
       "path": "../../src/Serilog.Sinks.MSSqlServer/project.json",
       "msbuildProject": "../../src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.xproj"


### PR DESCRIPTION
I'm _pretty_ sure this isn't the right way to fix it, but wanted to get some eyes on it in case it gives some clues about the underlying issue, https://github.com/serilog/serilog-sinks-mssqlserver/issues/31.

I have an integration test demonstrating that this works, but since it relies on localdb and uses Dapper, I thought it best not to include that here. You can see it at https://github.com/colin-young/serilog-sinks-mssqlserver/blob/localdb-tests/test/Serilog.Sinks.MSSqlServer.Tests/CustomStandardColumnNames.cs in `WriteEventToDefaultStandardColumns`.

Like I said, not the right fix, but wanted to get some input on what direction to go from here. My head hurts from trying to track the state of everything during `CloseAndFlush` and `Dispose`.