### PR TITLE
Fix to write events using custom column names

### DIFF
--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -253,25 +253,25 @@ namespace Serilog.Sinks.MSSqlServer
                     switch (column)
                     {
                         case StandardColumn.Message:
-                            row["Message"] = logEvent.RenderMessage(_formatProvider);
+                            row[_columnOptions.Message.ColumnName ?? "Message"] = logEvent.RenderMessage(_formatProvider);
                             break;
                         case StandardColumn.MessageTemplate:
-                            row["MessageTemplate"] = logEvent.MessageTemplate;
+                            row[_columnOptions.MessageTemplate.ColumnName ?? "MessageTemplate"] = logEvent.MessageTemplate;
                             break;
                         case StandardColumn.Level:
-                            row["Level"] = logEvent.Level;
+                            row[_columnOptions.Level.ColumnName ?? "Level"] = logEvent.Level;
                             break;
                         case StandardColumn.TimeStamp:
-                            row["TimeStamp"] = _columnOptions.TimeStamp.ConvertToUtc ? logEvent.Timestamp.DateTime.ToUniversalTime() : logEvent.Timestamp.DateTime;
+                            row[_columnOptions.TimeStamp.ColumnName ?? "TimeStamp"] = _columnOptions.TimeStamp.ConvertToUtc ? logEvent.Timestamp.DateTime.ToUniversalTime() : logEvent.Timestamp.DateTime;
                             break;
                         case StandardColumn.Exception:
-                            row["Exception"] = logEvent.Exception != null ? logEvent.Exception.ToString() : null;
+                            row[_columnOptions.Exception.ColumnName ?? "Exception"] = logEvent.Exception != null ? logEvent.Exception.ToString() : null;
                             break;
                         case StandardColumn.Properties:
-                            row["Properties"] = ConvertPropertiesToXmlStructure(logEvent.Properties);
+                            row[_columnOptions.Properties.ColumnName ?? "Properties"] = ConvertPropertiesToXmlStructure(logEvent.Properties);
                             break;
                         case StandardColumn.LogEvent:
-                            row["LogEvent"] = LogEventToJson(logEvent);
+                            row[_columnOptions.LogEvent.ColumnName ?? "LogEvent"] = LogEventToJson(logEvent);
                             break;
                         default:
                             throw new ArgumentOutOfRangeException();


### PR DESCRIPTION
As it turns out, I apparently never unit-tested actually writing an event to the log using custom column names. While the table structure got created as expected, once you attempted to actually write an event to the table you'd get an error.

Spent several days untangling an Autofac/serilog-extensions-logging mess only to discover that the problem wasn't in my code, it was in the sink. The bit that I modified. So, my code.

I'll create another PR for the local db test additions.