### PR TITLE
Log structured object in database.

### DIFF
--- a/serilog-sinks-mssqlserver.sln
+++ b/serilog-sinks-mssqlserver.sln
@@ -8,6 +8,10 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Serilog.Sinks.MSSqlServer", "src\Serilog.Sinks.MSSqlServer\Serilog.Sinks.MSSqlServer.xproj", "{803CD13A-D54B-4CEC-A55F-E22AE3D93B3C}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{F02D6513-6F45-452E-85A0-41A872A2C1F8}"
+	ProjectSection(SolutionItems) = preProject
+		src\Serilog.Sinks.MSSqlServer\project.json = src\Serilog.Sinks.MSSqlServer\project.json
+		src\Serilog.Sinks.MSSqlServer\project.lock.json = src\Serilog.Sinks.MSSqlServer\project.lock.json
+	EndProjectSection
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Serilog.Sinks.MSSqlServer.Tests", "test\Serilog.Sinks.MSSqlServer.Tests\Serilog.Sinks.MSSqlServer.Tests.xproj", "{3C2D8E01-5580-426A-BDD9-EC59CD98E618}"
 EndProject

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/LogEventToDataRowConverter.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/LogEventToDataRowConverter.cs
@@ -1,0 +1,227 @@
+﻿using System;
+using System.Data;
+using Serilog.Events;
+using System.Text;
+using System.Linq;
+using System.Collections.Generic;
+using Serilog.Formatting.Json;
+
+namespace Serilog.Sinks.MSSqlServer
+{
+    internal class LogEventToDataRowConverter
+    {
+        private readonly ColumnOptions _columnOptions;
+        readonly IFormatProvider _formatProvider;
+        private readonly HashSet<string> _additionalDataColumnNames;
+        private readonly JsonFormatter _jsonFormatter;
+        
+        public LogEventToDataRowConverter(IFormatProvider formatProvider, ColumnOptions columnOptions = null, JsonFormatter formatter = null)
+        {
+            _columnOptions = columnOptions;
+            _formatProvider = formatProvider;
+            _jsonFormatter = formatter;
+
+            if (_columnOptions.AdditionalDataColumns != null)
+            {
+                _additionalDataColumnNames = new HashSet<string>(_columnOptions.AdditionalDataColumns.Select(c => c.ColumnName), StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        public void FillRow(DataRow row, LogEvent logEvent)
+        {
+            foreach (var column in _columnOptions.Store)
+            {
+                switch (column)
+                {
+                    case StandardColumn.Message:
+                        row[_columnOptions.Message.ColumnName ?? "Message"] = logEvent.RenderMessage(_formatProvider);
+                        break;
+                    case StandardColumn.MessageTemplate:
+                        row[_columnOptions.MessageTemplate.ColumnName ?? "MessageTemplate"] = logEvent.MessageTemplate;
+                        break;
+                    case StandardColumn.Level:
+                        row[_columnOptions.Level.ColumnName ?? "Level"] = logEvent.Level;
+                        break;
+                    case StandardColumn.TimeStamp:
+                        row[_columnOptions.TimeStamp.ColumnName ?? "TimeStamp"] = _columnOptions.TimeStamp.ConvertToUtc ? logEvent.Timestamp.DateTime.ToUniversalTime() : logEvent.Timestamp.DateTime;
+                        break;
+                    case StandardColumn.Exception:
+                        row[_columnOptions.Exception.ColumnName ?? "Exception"] = logEvent.Exception != null ? logEvent.Exception.ToString() : null;
+                        break;
+                    case StandardColumn.Properties:
+                        row[_columnOptions.Properties.ColumnName ?? "Properties"] = ConvertPropertiesToXmlStructure(logEvent.Properties);
+                        break;
+                    case StandardColumn.LogEvent:
+                        row[_columnOptions.LogEvent.ColumnName ?? "LogEvent"] = LogEventToJson(logEvent);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+
+            if (_columnOptions.AdditionalDataColumns != null)
+            {
+                ConvertPropertiesToColumn(row, logEvent.Properties);
+            }
+        }
+
+        private string LogEventToJson(LogEvent logEvent)
+        {
+            if (_columnOptions.LogEvent.ExcludeAdditionalProperties)
+            {
+                var filteredProperties = logEvent.Properties.Where(p => !_additionalDataColumnNames.Contains(p.Key));
+                logEvent = new LogEvent(logEvent.Timestamp, logEvent.Level, logEvent.Exception, logEvent.MessageTemplate, filteredProperties.Select(x => new LogEventProperty(x.Key, x.Value)));
+            }
+
+            var sb = new StringBuilder();
+            using (var writer = new System.IO.StringWriter(sb))
+            {
+                _jsonFormatter.Format(logEvent, writer);
+            }
+                
+            return sb.ToString();
+        }
+
+        private string ConvertPropertiesToXmlStructure(IEnumerable<KeyValuePair<string, LogEventPropertyValue>> properties)
+        {
+            var options = _columnOptions.Properties;
+
+            if (options.ExcludeAdditionalProperties)
+                properties = properties.Where(p => !_additionalDataColumnNames.Contains(p.Key));
+
+            var sb = new StringBuilder();
+
+            sb.AppendFormat("<{0}>", options.RootElementName);
+
+            foreach (var property in properties)
+            {
+                var value = XmlPropertyFormatter.Simplify(property.Value, options);
+                if (options.OmitElementIfEmpty && string.IsNullOrEmpty(value))
+                {
+                    continue;
+                }
+
+                if (options.UsePropertyKeyAsElementName)
+                {
+                    sb.AppendFormat("<{0}>{1}</{0}>", XmlPropertyFormatter.GetValidElementName(property.Key), value);
+                }
+                else
+                {
+                    sb.AppendFormat("<{0} key='{1}'>{2}</{0}>", options.PropertyElementName, property.Key, value);
+                }
+            }
+
+            sb.AppendFormat("</{0}>", options.RootElementName);
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        ///     Mapping values from properties which have a corresponding data row.
+        ///     Matching is done based on Column name and property key
+        /// </summary>
+        /// <param name="row"></param>
+        /// <param name="properties"></param>
+        private void ConvertPropertiesToColumn(DataRow row, IReadOnlyDictionary<string, LogEventPropertyValue> properties)
+        {
+            foreach (var property in properties)
+            {
+                if (property.Value is ScalarValue)
+                {
+                    if (!row.Table.Columns.Contains(property.Key))
+                        continue;
+
+                    var columnName = property.Key;
+                    var columnType = row.Table.Columns[columnName].DataType;
+                    object conversion;
+
+                    var scalarValue = (ScalarValue)property.Value;
+
+                    if (scalarValue.Value == null && row.Table.Columns[columnName].AllowDBNull)
+                    {
+                        row[columnName] = DBNull.Value;
+                        continue;
+                    }
+
+                    if (TryChangeType(scalarValue.Value, columnType, out conversion))
+                    {
+                        row[columnName] = conversion;
+                    }
+                    else
+                    {
+                        row[columnName] = property.Value.ToString();
+                    }
+                }
+                else if (property.Value is StructureValue)
+                {
+                    var value = (StructureValue)property.Value;
+
+                    var values = value.Properties.ToDictionary(x => x.Name, x => x.Value);
+
+                    ConvertSubLevel(row, values);
+                }
+                else
+                {
+                    row[property.Key] = property.Value.ToString();
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Try to convert the object to the given type
+        /// </summary>
+        /// <param name="obj">object</param>
+        /// <param name="type">type to convert to</param>
+        /// <param name="conversion">result of the converted value</param>        
+        private static bool TryChangeType(object obj, Type type, out object conversion)
+        {
+            conversion = null;
+            try
+            {
+                conversion = Convert.ChangeType(obj, type);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private void ConvertSubLevel(DataRow row, IReadOnlyDictionary<string, LogEventPropertyValue> properties)
+        {
+            foreach (var property in properties)
+            {
+                if (!row.Table.Columns.Contains(property.Key))
+                    continue;
+
+                if (property.Value is ScalarValue)
+                {
+                    var columnName = property.Key;
+                    var columnType = row.Table.Columns[columnName].DataType;
+                    object conversion;
+
+                    var scalarValue = (ScalarValue)property.Value;
+
+                    if (scalarValue.Value == null && row.Table.Columns[columnName].AllowDBNull)
+                    {
+                        row[columnName] = DBNull.Value;
+                        continue;
+                    }
+
+                    if (TryChangeType(scalarValue.Value, columnType, out conversion))
+                    {
+                        row[columnName] = conversion;
+                    }
+                    else
+                    {
+                        row[columnName] = property.Value.ToString();
+                    }
+                }
+                else
+                {
+                    row[property.Key] = property.Value.ToString();
+                }
+            }
+        }
+    }
+}

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -51,9 +51,8 @@ namespace Serilog.Sinks.MSSqlServer
         readonly string _schemaName;
         private readonly ColumnOptions _columnOptions;
 
-        private readonly HashSet<string> _additionalDataColumnNames;
-
         private readonly JsonFormatter _jsonFormatter;
+        private readonly LogEventToDataRowConverter _converter;
 
 
         /// <summary>
@@ -90,15 +89,14 @@ namespace Serilog.Sinks.MSSqlServer
             _schemaName = schemaName;
             _formatProvider = formatProvider;
             _columnOptions = columnOptions ?? new ColumnOptions();
-            if (_columnOptions.AdditionalDataColumns != null)
-                _additionalDataColumnNames = new HashSet<string>(_columnOptions.AdditionalDataColumns.Select(c => c.ColumnName), StringComparer.OrdinalIgnoreCase);
 
             if (_columnOptions.Store.Contains(StandardColumn.LogEvent))
                 _jsonFormatter = new JsonFormatter(formatProvider: formatProvider);
-
+            
             // Prepare the data table
             _eventsTable = CreateDataTable();
 
+            _converter = new LogEventToDataRowConverter(_formatProvider, _columnOptions, _jsonFormatter);
             if (autoCreateSqlTable)
             {
                 try
@@ -255,154 +253,12 @@ namespace Serilog.Sinks.MSSqlServer
             {
                 var row = _eventsTable.NewRow();
 
-                foreach (var column in _columnOptions.Store)
-                {
-                    switch (column)
-                    {
-                        case StandardColumn.Message:
-                            row[_columnOptions.Message.ColumnName ?? "Message"] = logEvent.RenderMessage(_formatProvider);
-                            break;
-                        case StandardColumn.MessageTemplate:
-                            row[_columnOptions.MessageTemplate.ColumnName ?? "MessageTemplate"] = logEvent.MessageTemplate;
-                            break;
-                        case StandardColumn.Level:
-                            row[_columnOptions.Level.ColumnName ?? "Level"] = logEvent.Level;
-                            break;
-                        case StandardColumn.TimeStamp:
-                            row[_columnOptions.TimeStamp.ColumnName ?? "TimeStamp"] = _columnOptions.TimeStamp.ConvertToUtc ? logEvent.Timestamp.DateTime.ToUniversalTime() : logEvent.Timestamp.DateTime;
-                            break;
-                        case StandardColumn.Exception:
-                            row[_columnOptions.Exception.ColumnName ?? "Exception"] = logEvent.Exception != null ? logEvent.Exception.ToString() : null;
-                            break;
-                        case StandardColumn.Properties:
-                            row[_columnOptions.Properties.ColumnName ?? "Properties"] = ConvertPropertiesToXmlStructure(logEvent.Properties);
-                            break;
-                        case StandardColumn.LogEvent:
-                            row[_columnOptions.LogEvent.ColumnName ?? "LogEvent"] = LogEventToJson(logEvent);
-                            break;
-                        default:
-                            throw new ArgumentOutOfRangeException();
-                    }
-                }
-
-                if (_columnOptions.AdditionalDataColumns != null)
-                {
-                    ConvertPropertiesToColumn(row, logEvent.Properties);
-                }
+                _converter.FillRow(row, logEvent);
 
                 _eventsTable.Rows.Add(row);
             }
 
             _eventsTable.AcceptChanges();
-        }
-
-        private string ConvertPropertiesToXmlStructure(IEnumerable<KeyValuePair<string, LogEventPropertyValue>> properties)
-        {
-            var options = _columnOptions.Properties;
-
-            if (options.ExcludeAdditionalProperties)
-                properties = properties.Where(p => !_additionalDataColumnNames.Contains(p.Key));
-
-            var sb = new StringBuilder();
-
-            sb.AppendFormat("<{0}>", options.RootElementName);
-
-            foreach (var property in properties)
-            {
-                var value = XmlPropertyFormatter.Simplify(property.Value, options);
-                if (options.OmitElementIfEmpty && string.IsNullOrEmpty(value))
-                {
-                    continue;
-                }
-
-                if (options.UsePropertyKeyAsElementName)
-                {
-                    sb.AppendFormat("<{0}>{1}</{0}>", XmlPropertyFormatter.GetValidElementName(property.Key), value);
-                }
-                else
-                {
-                    sb.AppendFormat("<{0} key='{1}'>{2}</{0}>", options.PropertyElementName, property.Key, value);
-                }
-            }
-
-            sb.AppendFormat("</{0}>", options.RootElementName);
-
-            return sb.ToString();
-        }
-
-        private string LogEventToJson(LogEvent logEvent)
-        {
-            if (_columnOptions.LogEvent.ExcludeAdditionalProperties)
-            {
-                var filteredProperties = logEvent.Properties.Where(p => !_additionalDataColumnNames.Contains(p.Key));
-                logEvent = new LogEvent(logEvent.Timestamp, logEvent.Level, logEvent.Exception, logEvent.MessageTemplate, filteredProperties.Select(x => new LogEventProperty(x.Key, x.Value)));
-            }
-
-            var sb = new StringBuilder();
-            using (var writer = new System.IO.StringWriter(sb))
-                _jsonFormatter.Format(logEvent, writer);
-            return sb.ToString();
-        }
-
-        /// <summary>
-        ///     Mapping values from properties which have a corresponding data row.
-        ///     Matching is done based on Column name and property key
-        /// </summary>
-        /// <param name="row"></param>
-        /// <param name="properties"></param>
-        private void ConvertPropertiesToColumn(DataRow row, IReadOnlyDictionary<string, LogEventPropertyValue> properties)
-        {
-            foreach (var property in properties)
-            {
-                if (!row.Table.Columns.Contains(property.Key))
-                    continue;
-
-                var columnName = property.Key;
-                var columnType = row.Table.Columns[columnName].DataType;
-                object conversion;
-
-                var scalarValue = property.Value as ScalarValue;
-                if (scalarValue == null)
-                {
-                    row[columnName] = property.Value.ToString();
-                    continue;
-                }
-
-                if (scalarValue.Value == null && row.Table.Columns[columnName].AllowDBNull)
-                {
-                    row[columnName] = DBNull.Value;
-                    continue;
-                }
-
-                if (TryChangeType(scalarValue.Value, columnType, out conversion))
-                {
-                    row[columnName] = conversion;
-                }
-                else
-                {
-                    row[columnName] = property.Value.ToString();
-                }
-            }
-        }
-
-        /// <summary>
-        ///     Try to convert the object to the given type
-        /// </summary>
-        /// <param name="obj">object</param>
-        /// <param name="type">type to convert to</param>
-        /// <param name="conversion">result of the converted value</param>        
-        private static bool TryChangeType(object obj, Type type, out object conversion)
-        {
-            conversion = null;
-            try
-            {
-                conversion = Convert.ChangeType(obj, type);
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
         }
 
         /// <summary>

--- a/test/Serilog.Sinks.MSSqlServer.Tests/DatabaseFixture.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/DatabaseFixture.cs
@@ -27,8 +27,8 @@ WITH ROLLBACK IMMEDIATE
 DROP DATABASE [{Database}]
 ";
 
-        public static string MasterConnectionString => @"Data Source=(LocalDb)\v11.0;Initial Catalog=Master;Integrated Security=True";
-        public static string LogEventsConnectionString => $@"Data Source=(LocalDb)\v11.0;Initial Catalog={Database};Integrated Security=True";
+        public static string MasterConnectionString => @"Data Source=.;Initial Catalog=Master;Integrated Security=True";
+        public static string LogEventsConnectionString => $@"Data Source=.;Initial Catalog={Database};Integrated Security=True";
 
         public class FileName
         {

--- a/test/Serilog.Sinks.MSSqlServer.Tests/DatabaseFixture.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/DatabaseFixture.cs
@@ -27,8 +27,8 @@ WITH ROLLBACK IMMEDIATE
 DROP DATABASE [{Database}]
 ";
 
-        public static string MasterConnectionString => @"Data Source=.;Initial Catalog=Master;Integrated Security=True";
-        public static string LogEventsConnectionString => $@"Data Source=.;Initial Catalog={Database};Integrated Security=True";
+        public static string MasterConnectionString => @"Data Source=(LocalDb)\v11.0;Initial Catalog=Master;Integrated Security=True";
+        public static string LogEventsConnectionString => $@"Data Source=(LocalDb)\v11.0;Initial Catalog={Database};Integrated Security=True";
 
         public class FileName
         {


### PR DESCRIPTION
This makes it possible to log an object directly, like `Log.Information("Log a structured object {@obj}", obj)` and persist the individual properties inside the database. 

For now it only handles one level, would need to determine what's the expected behavior for several levels of complex objects.