### PR TITLE
Added support for AuditTo (Fixes #110)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.{csproj,json,config,yml}]
+indent_size = 2
+
+[*.sh]
+end_of_line = lf
+
+[*.{cmd, bat}]
+end_of_line = crlf

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerAuditSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerAuditSink.cs
@@ -1,0 +1,144 @@
+﻿// Copyright 2018 Serilog Contributors 
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Core;
+using Serilog.Debugging;
+using Serilog.Events;
+using System;
+using System.Data;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Text;
+
+namespace Serilog.Sinks.MSSqlServer
+{
+    /// <summary>
+    ///  Writes log events as rows in a table of MSSqlServer database using Audit logic, meaning that each row is synchronously committed
+    ///  and any errors that occur are propagated to the caller.
+    /// </summary>
+    public class MSSqlServerAuditSink : ILogEventSink, IDisposable
+    {
+        private readonly MSSqlServerSinkTraits _traits;
+
+        /// <summary>
+        ///     Construct a sink posting to the specified database.
+        /// </summary>
+        /// <param name="connectionString">Connection string to access the database.</param>
+        /// <param name="tableName">Name of the table to store the data in.</param>
+        /// <param name="schemaName">Name of the schema for the table to store the data in. The default is 'dbo'.</param>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="autoCreateSqlTable">Create log table with the provided name on destination sql server.</param>
+        /// <param name="columnOptions">Options that pertain to columns</param>
+        public MSSqlServerAuditSink(
+            string connectionString,
+            string tableName,
+            IFormatProvider formatProvider,
+            bool autoCreateSqlTable = false,
+            ColumnOptions columnOptions = null,
+            string schemaName = "dbo"
+            )
+        {
+            if (columnOptions != null)
+            {
+                if (columnOptions.DisableTriggers)
+                    throw new NotSupportedException($"The {nameof(ColumnOptions.DisableTriggers)} option is not supported for auditing.");
+            }
+            _traits = new MSSqlServerSinkTraits(connectionString, tableName, schemaName, columnOptions, formatProvider, autoCreateSqlTable);
+
+
+        }
+
+        /// <summary>Emit the provided log event to the sink.</summary>
+        /// <param name="logEvent">The log event to write.</param>
+        public void Emit(LogEvent logEvent)
+        {
+            try
+            {
+                using (SqlConnection connection = new SqlConnection(_traits.ConnectionString))
+                {
+                    connection.Open();
+                    using (SqlCommand command = connection.CreateCommand())
+                    {
+                        command.CommandType = CommandType.Text;
+
+                        StringBuilder fieldList = new StringBuilder($"INSERT INTO [{_traits.SchemaName}].[{_traits.TableName}] (");
+                        StringBuilder parameterList = new StringBuilder(") VALUES (");
+
+                        int index = 0;
+                        foreach (var field in _traits.GetColumnsAndValues(logEvent))
+                        {
+                            if (index != 0)
+                            {
+                                fieldList.Append(',');
+                                parameterList.Append(',');
+                            }
+
+                            fieldList.Append(field.Key);
+                            parameterList.Append("@P");
+                            parameterList.Append(index);
+
+                            SqlParameter parameter = new SqlParameter($"@P{index}", field.Value ?? DBNull.Value);                            
+
+                            // The default is SqlDbType.DateTime, which will truncate the DateTime value if the actual
+                            // type in the database table is datetime2. So we explicitly set it to DateTime2, which will
+                            // work both if the field in the table is datetime and datetime2, which is also consistent with 
+                            // the behavior of the non-audit sink.
+                            if (field.Value is DateTime)
+                                parameter.SqlDbType = SqlDbType.DateTime2;
+
+                            command.Parameters.Add(parameter);
+
+                            index++;
+                        }
+
+                        parameterList.Append(')');
+                        fieldList.Append(parameterList.ToString());
+
+                        command.CommandText = fieldList.ToString();
+
+                        command.ExecuteNonQuery();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                SelfLog.WriteLine("Unable to write log event to the database due to following error: {1}", ex.Message);
+                throw;
+            }            
+        }
+
+        /// <summary>
+        /// Releases the unmanaged resources used by the Serilog.Sinks.MSSqlServer.MSSqlServerAuditSink and optionally
+        /// releases the managed resources.
+        /// </summary>
+        /// <param name="disposing">True to release both managed and unmanaged resources; false to release only unmanaged
+        ///                         resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _traits.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2013 Serilog Contributors 
+﻿// Copyright 2018 Serilog Contributors 
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,10 +16,12 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlClient;
+using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Serilog.Core;
 using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Formatting.Json;
@@ -43,18 +45,7 @@ namespace Serilog.Sinks.MSSqlServer
         /// </summary>
         public static readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(5);
 
-        readonly string _connectionString;
-
-        private DataTable _eventsTable;
-        readonly IFormatProvider _formatProvider;
-        readonly string _tableName;
-        readonly string _schemaName;
-        private readonly ColumnOptions _columnOptions;
-
-        private readonly HashSet<string> _additionalDataColumnNames;
-
-        private readonly JsonFormatter _jsonFormatter;
-
+        private readonly MSSqlServerSinkTraits _traits;
 
         /// <summary>
         ///     Construct a sink posting to the specified database.
@@ -79,39 +70,7 @@ namespace Serilog.Sinks.MSSqlServer
             )
             : base(batchPostingLimit, period)
         {
-            if (string.IsNullOrWhiteSpace(connectionString))
-                throw new ArgumentNullException("connectionString");
-
-            if (string.IsNullOrWhiteSpace(tableName))
-                throw new ArgumentNullException("tableName");
-
-            _connectionString = connectionString;
-            _tableName = tableName;
-            _schemaName = schemaName;
-            _formatProvider = formatProvider;
-            _columnOptions = columnOptions ?? new ColumnOptions();
-            if (_columnOptions.AdditionalDataColumns != null)
-                _additionalDataColumnNames = new HashSet<string>(_columnOptions.AdditionalDataColumns.Select(c => c.ColumnName), StringComparer.OrdinalIgnoreCase);
-
-            if (_columnOptions.Store.Contains(StandardColumn.LogEvent))
-                _jsonFormatter = new JsonFormatter(formatProvider: formatProvider);
-
-            // Prepare the data table
-            _eventsTable = CreateDataTable();
-
-            if (autoCreateSqlTable)
-            {
-                try
-                {
-                    SqlTableCreator tableCreator = new SqlTableCreator(connectionString, _schemaName);
-                    tableCreator.CreateTable(_eventsTable);
-                }
-                catch (Exception ex)
-                {
-                    SelfLog.WriteLine("Exception {0} caught while creating table {1} to the database specified in the Connection string.", (object)ex, (object)tableName);
-                }
-
-            }
+            _traits = new MSSqlServerSinkTraits(connectionString, tableName, schemaName, columnOptions, formatProvider, autoCreateSqlTable);
         }
 
         /// <summary>
@@ -130,23 +89,23 @@ namespace Serilog.Sinks.MSSqlServer
 
             try
             {
-                using (var cn = new SqlConnection(_connectionString))
+                using (var cn = new SqlConnection(_traits.ConnectionString))
                 {
                     await cn.OpenAsync().ConfigureAwait(false);
-                    using (var copy = _columnOptions.DisableTriggers
+                    using (var copy = _traits.ColumnOptions.DisableTriggers
                             ? new SqlBulkCopy(cn)
                             : new SqlBulkCopy(cn, SqlBulkCopyOptions.CheckConstraints | SqlBulkCopyOptions.FireTriggers, null)
                     )
                     {
-                        copy.DestinationTableName = string.Format("[{0}].[{1}]", _schemaName, _tableName);
-                        foreach (var column in _eventsTable.Columns)
+                        copy.DestinationTableName = string.Format("[{0}].[{1}]", _traits.SchemaName, _traits.TableName);
+                        foreach (var column in _traits.EventTable.Columns)
                         {
                             var columnName = ((DataColumn)column).ColumnName;
                             var mapping = new SqlBulkCopyColumnMapping(columnName, columnName);
                             copy.ColumnMappings.Add(mapping);
                         }
 
-                        await copy.WriteToServerAsync(_eventsTable).ConfigureAwait(false);
+                        await copy.WriteToServerAsync(_traits.EventTable).ConfigureAwait(false);
                     }
                 }
             }
@@ -157,95 +116,8 @@ namespace Serilog.Sinks.MSSqlServer
             finally
             {
                 // Processed the items, clear for the next run
-                _eventsTable.Clear();
+                _traits.EventTable.Clear();
             }
-        }
-
-        DataTable CreateDataTable()
-        {
-            var eventsTable = new DataTable(_tableName);
-
-            var id = new DataColumn
-            {
-                DataType = Type.GetType("System.Int32"),
-                ColumnName = !string.IsNullOrWhiteSpace(_columnOptions.Id.ColumnName) ? _columnOptions.Id.ColumnName : "Id",
-                AutoIncrement = true
-            };
-            eventsTable.Columns.Add(id);
-
-            foreach (var standardColumn in _columnOptions.Store)
-            {
-                switch (standardColumn)
-                {
-                    case StandardColumn.Level:
-                        eventsTable.Columns.Add(new DataColumn
-                        {
-                            DataType = _columnOptions.Level.StoreAsEnum ? typeof(byte) : typeof(string),
-                            MaxLength = _columnOptions.Level.StoreAsEnum ? -1 : 128,
-                            ColumnName = _columnOptions.Level.ColumnName ?? StandardColumn.Level.ToString()
-                        });
-                        break;
-                    case StandardColumn.TimeStamp:
-                        eventsTable.Columns.Add(new DataColumn
-                        {
-                            DataType = typeof(DateTime),
-                            ColumnName = _columnOptions.TimeStamp.ColumnName ?? StandardColumn.TimeStamp.ToString(),
-                            AllowDBNull = false
-                        });
-                        break;
-                    case StandardColumn.LogEvent:
-                        eventsTable.Columns.Add(new DataColumn
-                        {
-                            DataType = typeof(string),
-                            ColumnName = _columnOptions.LogEvent.ColumnName ?? StandardColumn.LogEvent.ToString()
-                        });
-                        break;
-                    case StandardColumn.Message:
-                        eventsTable.Columns.Add(new DataColumn
-                        {
-                            DataType = typeof(string),
-                            MaxLength = -1,
-                            ColumnName = _columnOptions.Message.ColumnName ?? StandardColumn.Message.ToString()
-                        });
-                        break;
-                    case StandardColumn.MessageTemplate:
-                        eventsTable.Columns.Add(new DataColumn
-                        {
-                            DataType = typeof(string),
-                            MaxLength = -1,
-                            ColumnName = _columnOptions.MessageTemplate.ColumnName ?? StandardColumn.MessageTemplate.ToString()
-                        });
-                        break;
-                    case StandardColumn.Exception:
-                        eventsTable.Columns.Add(new DataColumn
-                        {
-                            DataType = typeof(string),
-                            MaxLength = -1,
-                            ColumnName = _columnOptions.Exception.ColumnName ?? StandardColumn.Exception.ToString()
-                        });
-                        break;
-                    case StandardColumn.Properties:
-                        eventsTable.Columns.Add(new DataColumn
-                        {
-                            DataType = typeof(string),
-                            MaxLength = -1,
-                            ColumnName = _columnOptions.Properties.ColumnName ?? StandardColumn.Properties.ToString()
-                        });
-                        break;
-                }
-            }
-
-            if (_columnOptions.AdditionalDataColumns != null)
-            {
-                eventsTable.Columns.AddRange(_columnOptions.AdditionalDataColumns.ToArray());
-            }
-
-            // Create an array for DataColumn objects.
-            var keys = new DataColumn[1];
-            keys[0] = id;
-            eventsTable.PrimaryKey = keys;
-
-            return eventsTable;
         }
 
         void FillDataTable(IEnumerable<LogEvent> events)
@@ -253,168 +125,17 @@ namespace Serilog.Sinks.MSSqlServer
             // Add the new rows to the collection. 
             foreach (var logEvent in events)
             {
-                var row = _eventsTable.NewRow();
+                var row = _traits.EventTable.NewRow();
 
-                foreach (var column in _columnOptions.Store)
+                foreach (var field in _traits.GetColumnsAndValues(logEvent))
                 {
-                    switch (column)
-                    {
-                        case StandardColumn.Message:
-                            row[_columnOptions.Message.ColumnName ?? "Message"] = logEvent.RenderMessage(_formatProvider);
-                            break;
-                        case StandardColumn.MessageTemplate:
-                            row[_columnOptions.MessageTemplate.ColumnName ?? "MessageTemplate"] = logEvent.MessageTemplate;
-                            break;
-                        case StandardColumn.Level:
-                            row[_columnOptions.Level.ColumnName ?? "Level"] = logEvent.Level;
-                            break;
-                        case StandardColumn.TimeStamp:
-                            row[_columnOptions.TimeStamp.ColumnName ?? "TimeStamp"] = _columnOptions.TimeStamp.ConvertToUtc ? logEvent.Timestamp.DateTime.ToUniversalTime() : logEvent.Timestamp.DateTime;
-                            break;
-                        case StandardColumn.Exception:
-                            row[_columnOptions.Exception.ColumnName ?? "Exception"] = logEvent.Exception != null ? logEvent.Exception.ToString() : null;
-                            break;
-                        case StandardColumn.Properties:
-                            row[_columnOptions.Properties.ColumnName ?? "Properties"] = ConvertPropertiesToXmlStructure(logEvent.Properties);
-                            break;
-                        case StandardColumn.LogEvent:
-                            row[_columnOptions.LogEvent.ColumnName ?? "LogEvent"] = LogEventToJson(logEvent);
-                            break;
-                        default:
-                            throw new ArgumentOutOfRangeException();
-                    }
+                    row[field.Key] = field.Value;
                 }
 
-                if (_columnOptions.AdditionalDataColumns != null)
-                {
-                    ConvertPropertiesToColumn(row, logEvent.Properties);
-                }
-
-                _eventsTable.Rows.Add(row);
+                _traits.EventTable.Rows.Add(row);
             }
 
-            _eventsTable.AcceptChanges();
-        }
-
-        private string ConvertPropertiesToXmlStructure(IEnumerable<KeyValuePair<string, LogEventPropertyValue>> properties)
-        {
-            var options = _columnOptions.Properties;
-
-            if (options.ExcludeAdditionalProperties)
-                properties = properties.Where(p => !_additionalDataColumnNames.Contains(p.Key));
-
-            if (options.PropertiesFilter != null)
-            {
-                try
-                {
-                    properties = properties.Where(p => options.PropertiesFilter(p.Key));
-                }
-                catch (Exception ex)
-                {
-                    SelfLog.WriteLine("Unable to filter properties to store in {0} due to following error: {1}", this, ex);
-                }
-            }
-
-            var sb = new StringBuilder();
-
-            sb.AppendFormat("<{0}>", options.RootElementName);
-
-            foreach (var property in properties)
-            {
-                var value = XmlPropertyFormatter.Simplify(property.Value, options);
-                if (options.OmitElementIfEmpty && string.IsNullOrEmpty(value))
-                {
-                    continue;
-                }
-
-                if (options.UsePropertyKeyAsElementName)
-                {
-                    sb.AppendFormat("<{0}>{1}</{0}>", XmlPropertyFormatter.GetValidElementName(property.Key), value);
-                }
-                else
-                {
-                    sb.AppendFormat("<{0} key='{1}'>{2}</{0}>", options.PropertyElementName, property.Key, value);
-                }
-            }
-
-            sb.AppendFormat("</{0}>", options.RootElementName);
-
-            return sb.ToString();
-        }
-
-        private string LogEventToJson(LogEvent logEvent)
-        {
-            if (_columnOptions.LogEvent.ExcludeAdditionalProperties)
-            {
-                var filteredProperties = logEvent.Properties.Where(p => !_additionalDataColumnNames.Contains(p.Key));
-                logEvent = new LogEvent(logEvent.Timestamp, logEvent.Level, logEvent.Exception, logEvent.MessageTemplate, filteredProperties.Select(x => new LogEventProperty(x.Key, x.Value)));
-            }
-
-            var sb = new StringBuilder();
-            using (var writer = new System.IO.StringWriter(sb))
-                _jsonFormatter.Format(logEvent, writer);
-            return sb.ToString();
-        }
-
-        /// <summary>
-        ///     Mapping values from properties which have a corresponding data row.
-        ///     Matching is done based on Column name and property key
-        /// </summary>
-        /// <param name="row"></param>
-        /// <param name="properties"></param>
-        private void ConvertPropertiesToColumn(DataRow row, IReadOnlyDictionary<string, LogEventPropertyValue> properties)
-        {
-            foreach (var property in properties)
-            {
-                if (!row.Table.Columns.Contains(property.Key))
-                    continue;
-
-                var columnName = property.Key;
-                var columnType = row.Table.Columns[columnName].DataType;
-                object conversion;
-
-                var scalarValue = property.Value as ScalarValue;
-                if (scalarValue == null)
-                {
-                    row[columnName] = property.Value.ToString();
-                    continue;
-                }
-
-                if (scalarValue.Value == null && row.Table.Columns[columnName].AllowDBNull)
-                {
-                    row[columnName] = DBNull.Value;
-                    continue;
-                }
-
-                if (TryChangeType(scalarValue.Value, columnType, out conversion))
-                {
-                    row[columnName] = conversion;
-                }
-                else
-                {
-                    row[columnName] = property.Value.ToString();
-                }
-            }
-        }
-
-        /// <summary>
-        ///     Try to convert the object to the given type
-        /// </summary>
-        /// <param name="obj">object</param>
-        /// <param name="type">type to convert to</param>
-        /// <param name="conversion">result of the converted value</param>        
-        private static bool TryChangeType(object obj, Type type, out object conversion)
-        {
-            conversion = null;
-            try
-            {
-                conversion = Convert.ChangeType(obj, type);
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
+            _traits.EventTable.AcceptChanges();
         }
 
         /// <summary>
@@ -424,11 +145,9 @@ namespace Serilog.Sinks.MSSqlServer
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
-
-            if (_eventsTable != null)
+            if (disposing)
             {
-                _eventsTable.Dispose();
-                _eventsTable = null;
+                _traits.Dispose();
             }
         }
     }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSinkTraits.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSinkTraits.cs
@@ -1,0 +1,331 @@
+﻿// Copyright 2018 Serilog Contributors 
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Debugging;
+using Serilog.Events;
+using Serilog.Formatting.Json;
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+
+namespace Serilog.Sinks.MSSqlServer
+{
+    /// <summary>Contains common functionality and properties used by both MSSqlServerSinks.</summary>
+    internal sealed class MSSqlServerSinkTraits : IDisposable
+    {
+        public string ConnectionString { get; }
+        public string TableName { get; }
+        public string SchemaName { get; }
+        public ColumnOptions ColumnOptions { get; }
+        public IFormatProvider FormatProvider { get; }
+        public JsonFormatter JsonFormatter { get; }
+        public ISet<string> AdditionalDataColumnNames { get; }
+        public DataTable EventTable { get; }
+
+        public MSSqlServerSinkTraits(string connectionString, string tableName, string schemaName, ColumnOptions columnOptions, IFormatProvider formatProvider, bool autoCreateSqlTable)
+        {
+            if (string.IsNullOrWhiteSpace(connectionString))
+                throw new ArgumentNullException(nameof(connectionString));
+
+            if (string.IsNullOrWhiteSpace(tableName))
+                throw new ArgumentNullException(nameof(tableName));
+
+            ConnectionString = connectionString;
+            TableName = tableName;
+            SchemaName = schemaName;
+            ColumnOptions = columnOptions ?? new ColumnOptions();
+            FormatProvider = formatProvider;
+
+            if (ColumnOptions.AdditionalDataColumns != null)
+                AdditionalDataColumnNames = new HashSet<string>(ColumnOptions.AdditionalDataColumns.Select(c => c.ColumnName), StringComparer.OrdinalIgnoreCase);
+
+            if (ColumnOptions.Store.Contains(StandardColumn.LogEvent))
+                JsonFormatter = new JsonFormatter(formatProvider: formatProvider);
+
+            EventTable = CreateDataTable();
+
+            if (autoCreateSqlTable)
+            {
+                try
+                {
+                    SqlTableCreator tableCreator = new SqlTableCreator(connectionString, SchemaName);
+                    tableCreator.CreateTable(EventTable);
+                }
+                catch (Exception ex)
+                {
+                    SelfLog.WriteLine("Exception {0} caught while creating table {1} to the database specified in the Connection string.", ex, tableName);
+                }
+
+            }
+        }
+
+        /// <summary>Gets a list of the column names paired with their values to emit for the specified <paramref name="logEvent"/>.</summary>
+        /// <param name="logEvent">The log event to emit.</param>
+        /// <returns>
+        /// A list of mappings between column names and values to emit to the database for the specified <paramref name="logEvent"/>.
+        /// </returns>
+        public IEnumerable<KeyValuePair<string, object>> GetColumnsAndValues(LogEvent logEvent)
+        {
+            foreach (var column in ColumnOptions.Store)
+            {
+                yield return GetStandardColumnNameAndValue(column, logEvent);
+            }
+
+            if (ColumnOptions.AdditionalDataColumns != null)
+            {
+                foreach (var columnValuePair in ConvertPropertiesToColumn(logEvent.Properties))
+                    yield return columnValuePair;
+            }
+        }
+
+        public void Dispose()
+        {
+            EventTable.Dispose();
+        }
+
+        private KeyValuePair<string, object> GetStandardColumnNameAndValue(StandardColumn column, LogEvent logEvent)
+        {
+            switch (column)
+            {
+                case StandardColumn.Message:
+                    return new KeyValuePair<string, object>(ColumnOptions.Message.ColumnName ?? "Message", logEvent.RenderMessage(FormatProvider));
+                case StandardColumn.MessageTemplate:
+                    return new KeyValuePair<string, object>(ColumnOptions.MessageTemplate.ColumnName ?? "MessageTemplate", logEvent.MessageTemplate.Text);
+                case StandardColumn.Level:
+                    return new KeyValuePair<string, object>(ColumnOptions.Level.ColumnName ?? "Level", ColumnOptions.Level.StoreAsEnum ? (object)logEvent.Level : logEvent.Level.ToString());
+                case StandardColumn.TimeStamp:
+                    return new KeyValuePair<string, object>(ColumnOptions.TimeStamp.ColumnName ?? "TimeStamp", ColumnOptions.TimeStamp.ConvertToUtc ? logEvent.Timestamp.DateTime.ToUniversalTime() : logEvent.Timestamp.DateTime);
+                case StandardColumn.Exception:
+                    return new KeyValuePair<string, object>(ColumnOptions.Exception.ColumnName ?? "Exception", logEvent.Exception != null ? logEvent.Exception.ToString() : null);
+                case StandardColumn.Properties:
+                    return new KeyValuePair<string, object>(ColumnOptions.Properties.ColumnName ?? "Properties", ConvertPropertiesToXmlStructure(logEvent.Properties));
+                case StandardColumn.LogEvent:
+                    return new KeyValuePair<string, object>(ColumnOptions.LogEvent.ColumnName ?? "LogEvent", LogEventToJson(logEvent));
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        private string LogEventToJson(LogEvent logEvent)
+        {
+            if (ColumnOptions.LogEvent.ExcludeAdditionalProperties)
+            {
+                var filteredProperties = logEvent.Properties.Where(p => !AdditionalDataColumnNames.Contains(p.Key));
+                logEvent = new LogEvent(logEvent.Timestamp, logEvent.Level, logEvent.Exception, logEvent.MessageTemplate, filteredProperties.Select(x => new LogEventProperty(x.Key, x.Value)));
+            }
+
+            var sb = new StringBuilder();
+            using (var writer = new System.IO.StringWriter(sb))
+                JsonFormatter.Format(logEvent, writer);
+            return sb.ToString();
+        }
+
+        private string ConvertPropertiesToXmlStructure(IEnumerable<KeyValuePair<string, LogEventPropertyValue>> properties)
+        {
+            var options = ColumnOptions.Properties;
+
+            if (options.ExcludeAdditionalProperties)
+                properties = properties.Where(p => !AdditionalDataColumnNames.Contains(p.Key));
+
+            if (options.PropertiesFilter != null)
+            {
+                try
+                {
+                    properties = properties.Where(p => options.PropertiesFilter(p.Key));
+                }
+                catch (Exception ex)
+                {
+                    SelfLog.WriteLine("Unable to filter properties to store in {0} due to following error: {1}", this, ex);
+                }
+            }
+
+            var sb = new StringBuilder();
+
+            sb.AppendFormat("<{0}>", options.RootElementName);
+
+            foreach (var property in properties)
+            {
+                var value = XmlPropertyFormatter.Simplify(property.Value, options);
+                if (options.OmitElementIfEmpty && string.IsNullOrEmpty(value))
+                {
+                    continue;
+                }
+
+                if (options.UsePropertyKeyAsElementName)
+                {
+                    sb.AppendFormat("<{0}>{1}</{0}>", XmlPropertyFormatter.GetValidElementName(property.Key), value);
+                }
+                else
+                {
+                    sb.AppendFormat("<{0} key='{1}'>{2}</{0}>", options.PropertyElementName, property.Key, value);
+                }
+            }
+
+            sb.AppendFormat("</{0}>", options.RootElementName);
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        ///     Mapping values from properties which have a corresponding data row.
+        ///     Matching is done based on Column name and property key
+        /// </summary>        
+        /// <param name="properties"></param>
+        private IEnumerable<KeyValuePair<string, object>> ConvertPropertiesToColumn(IReadOnlyDictionary<string, LogEventPropertyValue> properties)
+        {
+            foreach (var property in properties)
+            {
+                if (!EventTable.Columns.Contains(property.Key))
+                    continue;
+
+                var columnName = property.Key;
+                var columnType = EventTable.Columns[columnName].DataType;
+                object conversion;
+
+                var scalarValue = property.Value as ScalarValue;
+                if (scalarValue == null)
+                {
+                    yield return new KeyValuePair<string, object>(columnName, property.Value.ToString());
+                    continue;
+                }
+
+                if (scalarValue.Value == null && EventTable.Columns[columnName].AllowDBNull)
+                {
+                    yield return new KeyValuePair<string, object>(columnName, DBNull.Value);
+                    continue;
+                }
+
+                if (TryChangeType(scalarValue.Value, columnType, out conversion))
+                {
+                    yield return new KeyValuePair<string, object>(columnName, conversion);
+                }
+                else
+                {
+                    yield return new KeyValuePair<string, object>(columnName, property.Value.ToString());
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Try to convert the object to the given type
+        /// </summary>
+        /// <param name="obj">object</param>
+        /// <param name="type">type to convert to</param>
+        /// <param name="conversion">result of the converted value</param>        
+        private static bool TryChangeType(object obj, Type type, out object conversion)
+        {
+            conversion = null;
+            try
+            {
+                conversion = Convert.ChangeType(obj, type);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private DataTable CreateDataTable()
+        {
+            var eventsTable = new DataTable(TableName);
+
+            var id = new DataColumn
+            {
+                DataType = typeof(Int32),
+                ColumnName = !string.IsNullOrWhiteSpace(ColumnOptions.Id.ColumnName) ? ColumnOptions.Id.ColumnName : "Id",
+                AutoIncrement = true
+            };
+            eventsTable.Columns.Add(id);
+
+            foreach (var standardColumn in ColumnOptions.Store)
+            {
+                switch (standardColumn)
+                {
+                    case StandardColumn.Level:
+                        eventsTable.Columns.Add(new DataColumn
+                        {
+                            DataType = ColumnOptions.Level.StoreAsEnum ? typeof(byte) : typeof(string),
+                            MaxLength = ColumnOptions.Level.StoreAsEnum ? -1 : 128,
+                            ColumnName = ColumnOptions.Level.ColumnName ?? StandardColumn.Level.ToString()
+                        });
+                        break;
+                    case StandardColumn.TimeStamp:
+                        eventsTable.Columns.Add(new DataColumn
+                        {
+                            DataType = typeof(DateTime),
+                            ColumnName = ColumnOptions.TimeStamp.ColumnName ?? StandardColumn.TimeStamp.ToString(),
+                            AllowDBNull = false
+                        });
+                        break;
+                    case StandardColumn.LogEvent:
+                        eventsTable.Columns.Add(new DataColumn
+                        {
+                            DataType = typeof(string),
+                            ColumnName = ColumnOptions.LogEvent.ColumnName ?? StandardColumn.LogEvent.ToString()
+                        });
+                        break;
+                    case StandardColumn.Message:
+                        eventsTable.Columns.Add(new DataColumn
+                        {
+                            DataType = typeof(string),
+                            MaxLength = -1,
+                            ColumnName = ColumnOptions.Message.ColumnName ?? StandardColumn.Message.ToString()
+                        });
+                        break;
+                    case StandardColumn.MessageTemplate:
+                        eventsTable.Columns.Add(new DataColumn
+                        {
+                            DataType = typeof(string),
+                            MaxLength = -1,
+                            ColumnName = ColumnOptions.MessageTemplate.ColumnName ?? StandardColumn.MessageTemplate.ToString()
+                        });
+                        break;
+                    case StandardColumn.Exception:
+                        eventsTable.Columns.Add(new DataColumn
+                        {
+                            DataType = typeof(string),
+                            MaxLength = -1,
+                            ColumnName = ColumnOptions.Exception.ColumnName ?? StandardColumn.Exception.ToString()
+                        });
+                        break;
+                    case StandardColumn.Properties:
+                        eventsTable.Columns.Add(new DataColumn
+                        {
+                            DataType = typeof(string),
+                            MaxLength = -1,
+                            ColumnName = ColumnOptions.Properties.ColumnName ?? StandardColumn.Properties.ToString()
+                        });
+                        break;
+                }
+            }
+
+            if (ColumnOptions.AdditionalDataColumns != null)
+            {
+                eventsTable.Columns.AddRange(ColumnOptions.AdditionalDataColumns.ToArray());
+            }
+
+            // Create an array for DataColumn objects.
+            var keys = new DataColumn[1];
+            keys[0] = id;
+            eventsTable.PrimaryKey = keys;
+
+            return eventsTable;
+        }
+
+    }
+}

--- a/src/Serilog.Sinks.MSSqlServer/packages.config
+++ b/src/Serilog.Sinks.MSSqlServer/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Serilog" version="2.0.0-beta-523" targetFramework="net45" />
+  <package id="Serilog" version="2.5.0" targetFramework="net45" />
   <package id="Serilog.Sinks.PeriodicBatching" version="2.0.0-beta-700" targetFramework="net45" />
 </packages>

--- a/test/Serilog.Sinks.MSSqlServer.Tests/LevelAsEnum.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/LevelAsEnum.cs
@@ -75,6 +75,66 @@ namespace Serilog.Sinks.MSSqlServer.Tests
                 logEvents.Should().Contain(e => e.Message.Contains(loggingInformationMessage) && e.Level == LogEventLevel.Information.ToString());
             }
         }
+
+        [Fact]
+        public void AuditCanStoreLevelAsEnum()
+        {
+            // arrange
+            const string tableName = "AuditLogEventsLevelAsEnum";
+            var loggerConfiguration = new LoggerConfiguration();
+            Log.Logger = loggerConfiguration.AuditTo.MSSqlServer(
+                connectionString: DatabaseFixture.LogEventsConnectionString,
+                tableName: tableName,
+                autoCreateSqlTable: true,
+                columnOptions: new ColumnOptions { Level = { StoreAsEnum = true } })
+                .CreateLogger();
+
+            var file = File.CreateText("LevelAsEnum.Audit.True.Enum.Self.log");
+            Serilog.Debugging.SelfLog.Enable(TextWriter.Synchronized(file));
+
+            // act
+            const string loggingInformationMessage = "Logging Information message";
+            Log.Information(loggingInformationMessage);
+            Log.CloseAndFlush();
+
+            // assert
+            using (var conn = new SqlConnection(DatabaseFixture.LogEventsConnectionString))
+            {
+                var logEvents = conn.Query<EnumLevelStandardLogColumns>($"SELECT Message, Level FROM {tableName}");
+
+                logEvents.Should().Contain(e => e.Message.Contains(loggingInformationMessage) && e.Level == 2);
+            }
+        }
+
+        [Fact]
+        public void AuditCanStoreLevelAsString()
+        {
+            // arrange
+            const string tableName = "LogEventsLevelAsString";
+            var loggerConfiguration = new LoggerConfiguration();
+            Log.Logger = loggerConfiguration.AuditTo.MSSqlServer(
+                connectionString: DatabaseFixture.LogEventsConnectionString,
+                tableName: tableName,
+                autoCreateSqlTable: true,
+                columnOptions: new ColumnOptions { Level = { StoreAsEnum = false } })
+                .CreateLogger();
+
+            var file = File.CreateText("LevelAsEnum.Audit.False.Self.log");
+            Serilog.Debugging.SelfLog.Enable(TextWriter.Synchronized(file));
+
+            // act
+            const string loggingInformationMessage = "Logging Information message";
+            Log.Information(loggingInformationMessage);
+            Log.CloseAndFlush();
+
+            // assert
+            using (var conn = new SqlConnection(DatabaseFixture.LogEventsConnectionString))
+            {
+                var logEvents = conn.Query<StringLevelStandardLogColumns>($"SELECT Message, Level FROM {tableName}");
+
+                logEvents.Should().Contain(e => e.Message.Contains(loggingInformationMessage) && e.Level == LogEventLevel.Information.ToString());
+            }
+        }
     }
 
     public class EnumLevelStandardLogColumns

--- a/test/Serilog.Sinks.MSSqlServer.Tests/TestPropertiesColumnFiltering.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/TestPropertiesColumnFiltering.cs
@@ -47,5 +47,40 @@ namespace Serilog.Sinks.MSSqlServer.Tests
                 logEvents.Should().NotContain(e => e.Properties.Contains("BValue"));
             }
         }
+
+        [Fact]
+        public void FilteredPropertiesWhenAuditing()
+        {
+            // arrange
+            var columnOptions = new ColumnOptions();
+            columnOptions.Properties.PropertiesFilter = (propName) => propName == "A";
+
+            Log.Logger = new LoggerConfiguration()
+                .AuditTo.MSSqlServer
+                (
+                    connectionString: DatabaseFixture.LogEventsConnectionString,
+                    tableName: DatabaseFixture.LogTableName,
+                    columnOptions: columnOptions,
+                    autoCreateSqlTable: true
+                )
+                .CreateLogger();
+
+            // act
+            Log.Logger
+                .ForContext("A", "AValue")
+                .ForContext("B", "BValue")
+                .Information("Logging message");
+
+            Log.CloseAndFlush();
+
+            // assert
+            using (var conn = new SqlConnection(DatabaseFixture.LogEventsConnectionString))
+            {
+                var logEvents = conn.Query<PropertiesColumns>($"SELECT Properties from {DatabaseFixture.LogTableName}");
+
+                logEvents.Should().Contain(e => e.Properties.Contains("AValue"));
+                logEvents.Should().NotContain(e => e.Properties.Contains("BValue"));
+            }
+        }
     }
 }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/TestTriggersOnLogTable.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/TestTriggersOnLogTable.cs
@@ -95,6 +95,62 @@ END");
             }
         }
 
+        [Fact]
+        public void TestAuditTriggerOnLogTableFire()
+        {
+            // arrange
+            var logTriggerTableName = $"TriggerAudit{DatabaseFixture.LogTableName}Trigger";
+            var logTableName = $"{DatabaseFixture.LogTableName}WithTrigger";
+            var loggerConfiguration = new LoggerConfiguration();
+            Log.Logger = loggerConfiguration.AuditTo.MSSqlServer(
+                connectionString: DatabaseFixture.LogEventsConnectionString,
+                tableName: logTableName,
+                autoCreateSqlTable: true,
+                columnOptions: new ColumnOptions())
+                .CreateLogger();
+
+            using (var conn = new SqlConnection(DatabaseFixture.LogEventsConnectionString))
+            {
+                conn.Execute($"CREATE TABLE {logTriggerTableName} ([Id] [UNIQUEIDENTIFIER] NOT NULL, [Data] [NVARCHAR](50) NOT NULL)");
+                conn.Execute($@"CREATE TRIGGER {logTriggerTableName}NoTrigger ON {logTableName} 
+AFTER INSERT 
+AS
+BEGIN 
+INSERT INTO {logTriggerTableName} VALUES (NEWID(), 'Data') 
+END");
+            }
+
+            // act
+            const string loggingInformationMessage = "Logging Information message";
+            Log.Information(loggingInformationMessage);
+
+            Log.CloseAndFlush();
+
+            // assert
+            using (var conn = new SqlConnection(DatabaseFixture.LogEventsConnectionString))
+            {
+                var logTriggerEvents = conn.Query<TestTriggerEntry>($"SELECT * FROM {logTriggerTableName}");
+
+                logTriggerEvents.Should().NotBeNullOrEmpty();
+            }
+        }
+
+        [Fact]        
+        public void TestAuditOptionsDisableTriggersOnLogTable_ThrowsNotSupportedException()
+        {
+            // arrange
+            var options = new ColumnOptions { DisableTriggers = true };
+            var logTriggerTableName = $"{DatabaseFixture.LogTableName}NoTrigger";
+            var logTableName = $"{DatabaseFixture.LogTableName}WithTrigger";
+            var loggerConfiguration = new LoggerConfiguration();
+            Assert.Throws<NotSupportedException>(() => loggerConfiguration.AuditTo.MSSqlServer(
+                connectionString: DatabaseFixture.LogEventsConnectionString,
+                tableName: logTableName,
+                autoCreateSqlTable: true,
+                columnOptions: options)
+                .CreateLogger());
+        }
+
         internal class TestTriggerEntry
         {
             public Guid Id { get; set; }


### PR DESCRIPTION
* Updated reference to Serilog version 2.5.0 as suggested in #110
* Added a new Sink `MSSqlServerAuditSink` that persists LogEvents to the database immediately and propagates any errors that occur.
* Moved, and refactored common functionality from `MSSqlServerSink` into `MSSqlServerSinkTraits` which is now used by both sinks.