### PR TITLE
 Allow to extend or remove predefined column

### DIFF
--- a/src/Serilog.Sinks.MSSqlServer/Configuration/ColumnConfig.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/ColumnConfig.cs
@@ -100,6 +100,16 @@ namespace Serilog.Configuration
         }
 
         /// <summary>
+        /// Define ExcludeAdditionalProperties format for LogEvent column.
+        /// </summary>
+        [ConfigurationProperty("ExcludeAdditionalProperties", IsRequired = false, IsKey = false, DefaultValue = false)]
+        public bool ExcludeAdditionalProperties
+        {
+            get { return (bool)this["ExcludeAdditionalProperties"]; }
+            set { this["ExcludeAdditionalProperties"] = value; }
+        }
+
+        /// <summary>
         /// Define ConvertToUtc format for datetime column.
         /// </summary>
         [ConfigurationProperty("ConvertToUtc", IsRequired = false, IsKey = false, DefaultValue = false)]

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/ColumnConfig.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/ColumnConfig.cs
@@ -78,5 +78,35 @@ namespace Serilog.Configuration
             get { return (bool)this["AllowNull"]; }
             set { this["AllowNull"] = value; }
         }
+
+        /// <summary>
+        /// Remove predefined column.
+        /// </summary>
+        [ConfigurationProperty("RemovePredefinedColumn", IsRequired = false, IsKey = false, DefaultValue = false)]
+        public bool RemovePredefinedColumn
+        {
+            get { return (bool)this["RemovePredefinedColumn"]; }
+            set { this["RemovePredefinedColumn"] = value; }
+        }
+
+        /// <summary>
+        /// Override predefined column.
+        /// </summary>
+        [ConfigurationProperty("OverridePredefinedColumn", IsRequired = false, IsKey = false, DefaultValue = false)]
+        public bool OverridePredefinedColumn
+        {
+            get { return (bool)this["OverridePredefinedColumn"]; }
+            set { this["OverridePredefinedColumn"] = value; }
+        }
+
+        /// <summary>
+        /// Define ConvertToUtc format for datetime column.
+        /// </summary>
+        [ConfigurationProperty("ConvertToUtc", IsRequired = false, IsKey = false, DefaultValue = false)]
+        public bool ConvertToUtc
+        {
+            get { return (bool)this["ConvertToUtc"]; }
+            set { this["ConvertToUtc"] = value; }
+        }
     }
 }

--- a/src/Serilog.Sinks.MSSqlServer/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/LoggerConfigurationMSSqlServerExtensions.cs
@@ -182,105 +182,126 @@ namespace Serilog
             foreach (ColumnConfig c in serviceConfigSection.Columns)
             {
                 // Set the type based on the defined SQL type from config
-                DataColumn column = new DataColumn(c.ColumnName);
-
-                Type dataType = null;
-
-                switch (c.DataType)
-                {
-                    case "bigint":
-                        dataType = typeof(long);
-                        break;
-                    case "varbinary":
-                    case "binary":
-                        dataType = Type.GetType("System.Byte[]");
-                        column.ExtendedProperties["DataLength"] = c.DataLength;
-                        break;
-                    case "bit":
-                        dataType = typeof(bool);
-                        break;
-                    case "char":
-                    case "nchar":
-                    case "ntext":
-                    case "nvarchar":
-                    case "text":
-                    case "varchar":
-                        dataType = Type.GetType("System.String");
-                        column.MaxLength = c.DataLength;
-                        break;
-                    case "date":
-                    case "datetime":
-                    case "datetime2":
-                    case "smalldatetime":
-                        dataType = typeof(DateTime);
-                        break;
-                    case "decimal":
-                    case "money":
-                    case "numeric":
-                    case "smallmoney":
-                        dataType = typeof(Decimal);
-                        break;
-                    case "float":
-                        dataType = typeof(double);
-                        break;
-                    case "int":
-                        dataType = typeof(int);
-                        break;
-                    case "real":
-                        dataType = typeof(float);
-                        break;
-                    case "smallint":
-                        dataType = typeof(short);
-                        break;
-                    case "time":
-                        dataType = typeof(TimeSpan);
-                        break;
-                    case "uniqueidentifier":
-                        dataType = typeof(Guid);
-                        break;
-                }
+                DataColumn column = CreateDataColumn(c);
 
                 if (c.RemovePredefinedColumn && Enum.TryParse(c.ColumnName, out StandardColumn standardColumn))
                 {
                     columnOptions.Store.Remove(standardColumn);
-                    return;
+                    continue;
                 }
-
-                if (c.OverridePredefinedColumn && Enum.TryParse(c.ColumnName, out standardColumn))
+                else if (c.OverridePredefinedColumn && Enum.TryParse(c.ColumnName, out standardColumn))
                 {
                     switch (standardColumn)
                     {
-                        case StandardColumn.Exception:
-                            break;
-                        case StandardColumn.Properties:
-                            break;
-                        case StandardColumn.Level:
-                            break;
-                        case StandardColumn.MessageTemplate:
-                            break;
-                        case StandardColumn.Message:
-                            break;
                         case StandardColumn.LogEvent:
+                            columnOptions.LogEvent.ExcludeAdditionalProperties = c.ExcludeAdditionalProperties;
+                            columnOptions.LogEvent.DataColumn = column;
+                            columnOptions.LogEvent.Overrided = true;
                             break;
                         case StandardColumn.TimeStamp:
                             columnOptions.TimeStamp.ConvertToUtc = c.ConvertToUtc;
+                            columnOptions.TimeStamp.DataColumn = column;
+                            columnOptions.TimeStamp.Overrided = true;
+                            break;
+                        case StandardColumn.Exception:
+                            columnOptions.Exception.DataColumn = column;
+                            columnOptions.Exception.Overrided = true;
+                            break;
+                        case StandardColumn.Properties:
+                            columnOptions.Properties.DataColumn = column;
+                            columnOptions.Properties.Overrided = true;
+                            break;
+                        case StandardColumn.Level:
+                            columnOptions.Level.DataColumn = column;
+                            columnOptions.Level.Overrided = true;
+                            break;
+                        case StandardColumn.MessageTemplate:
+                            columnOptions.MessageTemplate.DataColumn = column;
+                            columnOptions.MessageTemplate.Overrided = true;
+                            break;
+                        case StandardColumn.Message:
+                            columnOptions.Message.DataColumn = column;
+                            columnOptions.Message.Overrided = true;
                             break;
                     }
 
-                    return;
+                    continue;
                 }
-
-                column.DataType = dataType;
-                column.AllowDBNull = c.AllowNull;
-
-
-                if (columnOptions.AdditionalDataColumns == null)
+                else
                 {
-                    columnOptions.AdditionalDataColumns = new Collection<DataColumn>();
-                }
+                    if (columnOptions.AdditionalDataColumns == null)
+                    {
+                        columnOptions.AdditionalDataColumns = new Collection<DataColumn>();
+                    }
 
-                columnOptions.AdditionalDataColumns.Add(column);
+                    columnOptions.AdditionalDataColumns.Add(column);
+                }
             }
+        }
+
+        private static DataColumn CreateDataColumn(ColumnConfig c)
+        {
+            DataColumn column = new DataColumn(c.ColumnName);
+            Type dataType = typeof(string);
+
+            switch (c.DataType)
+            {
+                case "bigint":
+                    dataType = typeof(long);
+                    break;
+                case "varbinary":
+                case "binary":
+                    dataType = Type.GetType("System.Byte[]");
+                    column.ExtendedProperties["DataLength"] = c.DataLength;
+                    break;
+                case "bit":
+                    dataType = typeof(bool);
+                    break;
+                case "char":
+                case "nchar":
+                case "ntext":
+                case "nvarchar":
+                case "text":
+                case "varchar":
+                    dataType = Type.GetType("System.String");
+                    column.MaxLength = c.DataLength;
+                    break;
+                case "date":
+                case "datetime":
+                case "datetime2":
+                case "smalldatetime":
+                    dataType = typeof(DateTime);
+                    break;
+                case "decimal":
+                case "money":
+                case "numeric":
+                case "smallmoney":
+                    dataType = typeof(Decimal);
+                    break;
+                case "float":
+                    dataType = typeof(double);
+                    break;
+                case "int":
+                    dataType = typeof(int);
+                    break;
+                case "real":
+                    dataType = typeof(float);
+                    break;
+                case "smallint":
+                    dataType = typeof(short);
+                    break;
+                case "time":
+                    dataType = typeof(TimeSpan);
+                    break;
+                case "uniqueidentifier":
+                    dataType = typeof(Guid);
+                    break;
+            }
+
+            column.DataType = dataType;
+            column.AllowDBNull = c.AllowNull;
+
+            return column;
         }
     }
 }

--- a/src/Serilog.Sinks.MSSqlServer/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/LoggerConfigurationMSSqlServerExtensions.cs
@@ -6,6 +6,7 @@ using Serilog.Configuration;
 using Serilog.Events;
 using Serilog.Sinks.MSSqlServer;
 using System.Configuration;
+using System.Linq;
 using Serilog.Debugging;
 
 // Copyright 2014 Serilog Contributors
@@ -239,8 +240,40 @@ namespace Serilog
                         break;
                 }
 
+                if (c.RemovePredefinedColumn && Enum.TryParse(c.ColumnName, out StandardColumn standardColumn))
+                {
+                    columnOptions.Store.Remove(standardColumn);
+                    return;
+                }
+
+                if (c.OverridePredefinedColumn && Enum.TryParse(c.ColumnName, out standardColumn))
+                {
+                    switch (standardColumn)
+                    {
+                        case StandardColumn.Exception:
+                            break;
+                        case StandardColumn.Properties:
+                            break;
+                        case StandardColumn.Level:
+                            break;
+                        case StandardColumn.MessageTemplate:
+                            break;
+                        case StandardColumn.Message:
+                            break;
+                        case StandardColumn.LogEvent:
+                            break;
+                        case StandardColumn.TimeStamp:
+                            columnOptions.TimeStamp.ConvertToUtc = c.ConvertToUtc;
+                            break;
+                    }
+
+                    return;
+                }
+
                 column.DataType = dataType;
                 column.AllowDBNull = c.AllowNull;
+
+
                 if (columnOptions.AdditionalDataColumns == null)
                 {
                     columnOptions.AdditionalDataColumns = new Collection<DataColumn>();

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions.cs
@@ -223,6 +223,16 @@ namespace Serilog.Sinks.MSSqlServer
             /// The name of the column in the database.
             /// </summary>
             public string ColumnName { get; set; }
+
+            /// <summary>
+            /// The data column of the column in the database.
+            /// </summary>
+            public DataColumn DataColumn { get; set; }
+
+            /// <summary>
+            /// The value indicates whether this column is overrided by configuration or not.
+            /// </summary>
+            public bool Overrided { get; set; }
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSinkTraits.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSinkTraits.cs
@@ -255,7 +255,7 @@ namespace Serilog.Sinks.MSSqlServer
                 switch (standardColumn)
                 {
                     case StandardColumn.Level:
-                        eventsTable.Columns.Add(new DataColumn
+                        eventsTable.Columns.Add(ColumnOptions.Level.Overrided ? ColumnOptions.Level.DataColumn : new DataColumn
                         {
                             DataType = ColumnOptions.Level.StoreAsEnum ? typeof(byte) : typeof(string),
                             MaxLength = ColumnOptions.Level.StoreAsEnum ? -1 : 128,
@@ -263,7 +263,7 @@ namespace Serilog.Sinks.MSSqlServer
                         });
                         break;
                     case StandardColumn.TimeStamp:
-                        eventsTable.Columns.Add(new DataColumn
+                        eventsTable.Columns.Add(ColumnOptions.TimeStamp.Overrided ? ColumnOptions.TimeStamp.DataColumn : new DataColumn
                         {
                             DataType = typeof(DateTime),
                             ColumnName = ColumnOptions.TimeStamp.ColumnName ?? StandardColumn.TimeStamp.ToString(),
@@ -271,14 +271,14 @@ namespace Serilog.Sinks.MSSqlServer
                         });
                         break;
                     case StandardColumn.LogEvent:
-                        eventsTable.Columns.Add(new DataColumn
+                        eventsTable.Columns.Add(ColumnOptions.LogEvent.Overrided ? ColumnOptions.LogEvent.DataColumn : new DataColumn
                         {
                             DataType = typeof(string),
                             ColumnName = ColumnOptions.LogEvent.ColumnName ?? StandardColumn.LogEvent.ToString()
                         });
                         break;
                     case StandardColumn.Message:
-                        eventsTable.Columns.Add(new DataColumn
+                        eventsTable.Columns.Add(ColumnOptions.Message.Overrided ? ColumnOptions.Message.DataColumn : new DataColumn
                         {
                             DataType = typeof(string),
                             MaxLength = -1,
@@ -286,7 +286,7 @@ namespace Serilog.Sinks.MSSqlServer
                         });
                         break;
                     case StandardColumn.MessageTemplate:
-                        eventsTable.Columns.Add(new DataColumn
+                        eventsTable.Columns.Add(ColumnOptions.MessageTemplate.Overrided ? ColumnOptions.MessageTemplate.DataColumn : new DataColumn
                         {
                             DataType = typeof(string),
                             MaxLength = -1,
@@ -294,7 +294,7 @@ namespace Serilog.Sinks.MSSqlServer
                         });
                         break;
                     case StandardColumn.Exception:
-                        eventsTable.Columns.Add(new DataColumn
+                        eventsTable.Columns.Add(ColumnOptions.Exception.Overrided ? ColumnOptions.Exception.DataColumn : new DataColumn
                         {
                             DataType = typeof(string),
                             MaxLength = -1,
@@ -302,7 +302,7 @@ namespace Serilog.Sinks.MSSqlServer
                         });
                         break;
                     case StandardColumn.Properties:
-                        eventsTable.Columns.Add(new DataColumn
+                        eventsTable.Columns.Add(ColumnOptions.Properties.Overrided ? ColumnOptions.Properties.DataColumn : new DataColumn
                         {
                             DataType = typeof(string),
                             MaxLength = -1,


### PR DESCRIPTION
Some predefined columns should be customized to support database index (nvarchar(max) doesn't support index) or able to removed when client doesn't need it.