### PR TITLE
Make Id optional, allow nonclustered PK, allow bigint Id

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ If you set the `autoCreateSqlTable` option to `true`, the sink will create a tab
 
 ### Permissions
 
+At a minimum, writing log entries requires SELECT and INSERT permissions for the log table. (SELECT is required because the sink's batching behavior uses bulk inserts which reads the schema before the write operations begin).
+
 SQL permissions are a very complex subject. Here is an example of one possible solution (valid for SQL 2012 or later):
 
 ```
@@ -154,7 +156,7 @@ There are many possible variations. For example, you could also create a new sch
 
 ## Id Column Options
 
-Previous versions of this sink assumed the Id column is always present as an `int` `IDENTITY` primary key with a clustered index. Other configurations are available, however this is still the default strictly for backwards-compatibility reasons.
+Previous versions of this sink assumed the Id column is always present as an `int` `IDENTITY` primary key with a clustered index. Other configurations are available, however this is still the default for backwards-compatibility reasons.
 
 You should consider your anticipated logging volume and query requirements carefully. The default setting is not especially useful in real-world query scenarios since a clustered index is primarily of use when the key is used for sorting or range searches, which will rarely be the case for the Id column.
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ If you eliminate the Id column completely, the log table is stored as an unindex
 
 ### Unclustered Id Column
 
-You can also retain the Id column as an `IDENTITY` primary key, but without a clustered index. The log is still stored as an unindexed heap, but writes with non-clustered indexes are slightly faster. The non-clustered indexes will reference the Id primary key. However, read performance will be slightly degraded since it requires two reads (the covering non-clustered index, then dereferencing the heap row from the Id). To create this type of table ahead of time, change the constraint in the previous section to `NONCLUSTERED` and leave out the `WITH` clause.
+You can also retain the Id column as an `IDENTITY` primary key, but using a non-clustered index. The log is still stored as an unindexed heap, but writes with non-clustered indexes are slightly faster. Non-clustered indexes on other columns will reference the Id primary key. However, read performance will be slightly degraded since it requires two reads (the covering non-clustered index, then dereferencing the heap row from the Id). To create this type of table ahead of time, change the constraint in the previous section to `NONCLUSTERED` and leave out the `WITH` clause.
 
 ### Bigint Data Type
 
@@ -291,7 +291,7 @@ As the name suggests, `columnOptionSection` is an entire configuration section i
         { "ColumnName": "Release", "DataType": "varchar", "DataLength": 32 }
     ],
     "disableTriggers": true,
-    "id": { "columnName": "Id", "bigint": true, "clusteredIndex": true },
+    "id": { "columnName": "Id", "bigint": true, "nonClusteredIndex": true },
     "level": { "columnName": "Level", "storeAsEnum": false },
     "properties": { 
         "columnName": "Properties",

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Microsoft.Extensions.Configuration/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Microsoft.Extensions.Configuration/LoggerConfigurationMSSqlServerExtensions.cs
@@ -221,7 +221,7 @@ namespace Serilog
             {
                 SetIfProvided<string>((val) => { opts.Id.ColumnName = val; }, section["columnName"]);
                 SetIfProvided<bool>((val) => { opts.Id.BigInt = val; }, section["bigInt"]);
-                SetIfProvided<bool>((val) => { opts.Id.ClusteredIndex = val; }, section["clusteredIndex"]);
+                SetIfProvided<bool>((val) => { opts.Id.NonClusteredIndex = val; }, section["nonClusteredIndex"]);
             }
 
             section = config.GetSection("level");
@@ -264,11 +264,11 @@ namespace Serilog
                 SetIfProvided<bool>((val) => { opts.LogEvent.ExcludeAdditionalProperties = val; }, section["excludeAdditionalProperties"]);
             }
 
-            SetIfProvided<string>((val) => { opts.Id.ColumnName = val; }, config.GetSection("message")["columnName"]);
+            SetIfProvided<string>((val) => { opts.Message.ColumnName = val; }, config.GetSection("message")["columnName"]);
 
-            SetIfProvided<string>((val) => { opts.Id.ColumnName = val; }, config.GetSection("exception")["columnName"]);
+            SetIfProvided<string>((val) => { opts.Exception.ColumnName = val; }, config.GetSection("exception")["columnName"]);
 
-            SetIfProvided<string>((val) => { opts.Id.ColumnName = val; }, config.GetSection("messageTemplate")["columnName"]);
+            SetIfProvided<string>((val) => { opts.MessageTemplate.ColumnName = val; }, config.GetSection("messageTemplate")["columnName"]);
 
             return opts;
 

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Microsoft.Extensions.Configuration/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Microsoft.Extensions.Configuration/LoggerConfigurationMSSqlServerExtensions.cs
@@ -216,9 +216,15 @@ namespace Serilog
 
             SetIfProvided<bool>((val) => { opts.DisableTriggers = val; }, config["disableTriggers"]);
 
-            SetIfProvided<string>((val) => { opts.Id.ColumnName = val; }, config.GetSection("id")["columnName"]);
+            var section = config.GetSection("id");
+            if (section.GetChildren().Any())
+            {
+                SetIfProvided<string>((val) => { opts.Id.ColumnName = val; }, section["columnName"]);
+                SetIfProvided<bool>((val) => { opts.Id.BigInt = val; }, section["bigInt"]);
+                SetIfProvided<bool>((val) => { opts.Id.ClusteredIndex = val; }, section["clusteredIndex"]);
+            }
 
-            var section = config.GetSection("level");
+            section = config.GetSection("level");
             if(section.GetChildren().Any())
             {
                 SetIfProvided<string>((val) => { opts.Level.ColumnName = val; }, section["columnName"]);

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions.cs
@@ -17,7 +17,12 @@ namespace Serilog.Sinks.MSSqlServer
         /// </summary>
         public ColumnOptions()
         {
-            Id = new IdColumnOptions();
+            Id = new IdColumnOptions
+            {
+                // Defaults for backwards compatibility only; not recommended, see docs
+                BigInt = false,
+                ClusteredIndex = true
+            };
 
             Level = new LevelColumnOptions();
 
@@ -25,6 +30,7 @@ namespace Serilog.Sinks.MSSqlServer
 
             Store = new Collection<StandardColumn>
             {
+                StandardColumn.Id,
                 StandardColumn.Message,
                 StandardColumn.MessageTemplate,
                 StandardColumn.Level,
@@ -116,7 +122,19 @@ namespace Serilog.Sinks.MSSqlServer
         /// <summary>
         ///     Options for the Id column.
         /// </summary>
-        public class IdColumnOptions : CommonColumnOptions { }
+        public class IdColumnOptions : CommonColumnOptions
+        {
+            /// <summary>
+            /// If true, stores as bigint (max value 2^64-1) instead of the default int.
+            /// </summary>
+            public bool BigInt { get; set; }
+
+            /// <summary>
+            /// If false, the log table will be stored as a heap structure. This will improve
+            /// write performance at the cost of query performance. See documentation for details.
+            /// </summary>
+            public bool ClusteredIndex { get; set; }
+        }
 
         /// <summary>
         ///     Options for the Level column.

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions.cs
@@ -19,9 +19,9 @@ namespace Serilog.Sinks.MSSqlServer
         {
             Id = new IdColumnOptions
             {
-                // Defaults for backwards compatibility only; not recommended, see docs
+                // Defaults for backwards compatibility, see docs
                 BigInt = false,
-                ClusteredIndex = true
+                NonClusteredIndex = false
             };
 
             Level = new LevelColumnOptions();
@@ -128,12 +128,6 @@ namespace Serilog.Sinks.MSSqlServer
             /// If true, stores as bigint (max value 2^64-1) instead of the default int.
             /// </summary>
             public bool BigInt { get; set; }
-
-            /// <summary>
-            /// If false, the log table will be stored as a heap structure. This will improve
-            /// write performance at the cost of query performance. See documentation for details.
-            /// </summary>
-            public bool ClusteredIndex { get; set; }
         }
 
         /// <summary>
@@ -241,6 +235,14 @@ namespace Serilog.Sinks.MSSqlServer
             /// The name of the column in the database.
             /// </summary>
             public string ColumnName { get; set; }
+
+            /// <summary>
+            /// Currently only implemented for the optional Id IDENTITY PK column. Defaults to false.
+            /// If true, the log table will be stored as a heap structure. This can improve
+            /// write performance at the cost of query performance. See documentation for details.
+            /// </summary>
+            public bool NonClusteredIndex { get; set; }
+
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSinkTraits.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSinkTraits.cs
@@ -51,8 +51,8 @@ namespace Serilog.Sinks.MSSqlServer
             ColumnOptions = columnOptions ?? new ColumnOptions();
             FormatProvider = formatProvider;
 
-            ExcludedColumnNames = new List<string>(ColumnOptions.Store.Count + 1);
-            ExcludedColumnNames.Add(ColumnOptions.Id.ColumnName ?? "Id");
+            ExcludedColumnNames = new List<string>(ColumnOptions.Store.Count);
+            if (ColumnOptions.Store.Contains(StandardColumn.Id)) ExcludedColumnNames.Add(ColumnOptions.Id.ColumnName ?? "Id");
             if (ColumnOptions.Store.Contains(StandardColumn.Message)) ExcludedColumnNames.Add(ColumnOptions.Message.ColumnName ?? "Message");
             if (ColumnOptions.Store.Contains(StandardColumn.MessageTemplate)) ExcludedColumnNames.Add(ColumnOptions.MessageTemplate.ColumnName ?? "MessageTemplate");
             if (ColumnOptions.Store.Contains(StandardColumn.Level)) ExcludedColumnNames.Add(ColumnOptions.Level.ColumnName ?? "Level");
@@ -93,7 +93,9 @@ namespace Serilog.Sinks.MSSqlServer
         {
             foreach (var column in ColumnOptions.Store)
             {
-                yield return GetStandardColumnNameAndValue(column, logEvent);
+                // never write to Id since it will be auto-incrementing (IDENTITY)
+                if(column != StandardColumn.Id)
+                    yield return GetStandardColumnNameAndValue(column, logEvent);
             }
 
             if (ColumnOptions.AdditionalDataColumns != null)
@@ -254,18 +256,26 @@ namespace Serilog.Sinks.MSSqlServer
         {
             var eventsTable = new DataTable(TableName);
 
-            var id = new DataColumn
-            {
-                DataType = typeof(Int32),
-                ColumnName = !string.IsNullOrWhiteSpace(ColumnOptions.Id.ColumnName) ? ColumnOptions.Id.ColumnName : "Id",
-                AutoIncrement = true
-            };
-            eventsTable.Columns.Add(id);
-
             foreach (var standardColumn in ColumnOptions.Store)
             {
                 switch (standardColumn)
                 {
+                    case StandardColumn.Id:
+                        var id = new DataColumn
+                        {
+                            DataType = ColumnOptions.Id.BigInt ? typeof(long) : typeof(int),
+                            ColumnName = ColumnOptions.Id.ColumnName ?? StandardColumn.Id.ToString(),
+                            AutoIncrement = true
+                        };
+                        eventsTable.Columns.Add(id);
+                        id.ExtendedProperties.Add("clusteredIndex", false);
+                        if(ColumnOptions.Id.ClusteredIndex)
+                        {
+                            id.ExtendedProperties["clusteredIndex"] = true;
+                            eventsTable.PrimaryKey = new DataColumn[] { id };
+                        }
+                        break;
+
                     case StandardColumn.Level:
                         eventsTable.Columns.Add(new DataColumn
                         {
@@ -328,11 +338,6 @@ namespace Serilog.Sinks.MSSqlServer
             {
                 eventsTable.Columns.AddRange(ColumnOptions.AdditionalDataColumns.ToArray());
             }
-
-            // Create an array for DataColumn objects.
-            var keys = new DataColumn[1];
-            keys[0] = id;
-            eventsTable.PrimaryKey = keys;
 
             return eventsTable;
         }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSinkTraits.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSinkTraits.cs
@@ -265,15 +265,12 @@ namespace Serilog.Sinks.MSSqlServer
                         {
                             DataType = ColumnOptions.Id.BigInt ? typeof(long) : typeof(int),
                             ColumnName = ColumnOptions.Id.ColumnName ?? StandardColumn.Id.ToString(),
-                            AutoIncrement = true
+                            AutoIncrement = true,
+                            AllowDBNull = false
                         };
+                        id.ExtendedProperties.Add("NonClusteredIndex", ColumnOptions.Id.NonClusteredIndex);
                         eventsTable.Columns.Add(id);
-                        id.ExtendedProperties.Add("clusteredIndex", false);
-                        if(ColumnOptions.Id.ClusteredIndex)
-                        {
-                            id.ExtendedProperties["clusteredIndex"] = true;
-                            eventsTable.PrimaryKey = new DataColumn[] { id };
-                        }
+                        eventsTable.PrimaryKey = new DataColumn[] { id };
                         break;
 
                     case StandardColumn.Level:

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlTableCreator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlTableCreator.cs
@@ -45,16 +45,14 @@ namespace Serilog.Sinks.MSSqlServer
 
             // columns
             bool hasPrimaryKey = false;
-            bool clusteredIndex = true;
             int numOfColumns = table.Columns.Count;
             int i = 1;
             foreach (DataColumn column in table.Columns)
             {
                 sql.AppendFormat("[{0}] {1}", column.ColumnName, SqlGetType(column));
-                if (column.ColumnName.ToUpper().Equals("ID") || column.AutoIncrement)
+                if (column.AutoIncrement) // the PK is always auto-increment (IDENTITY)
                 {
                     hasPrimaryKey = true;
-                    clusteredIndex = (bool)column.ExtendedProperties["clusteredIndex"];
                     sql.Append(" IDENTITY(1,1) ");
                 }
                 if (numOfColumns > i)
@@ -65,6 +63,7 @@ namespace Serilog.Sinks.MSSqlServer
             // primary keys
             if (hasPrimaryKey)
             {
+                var clusteredIndex = (bool)table.PrimaryKey[0].ExtendedProperties["clusteredIndex"];
                 sql.AppendFormat(" CONSTRAINT [PK_{0}] PRIMARY KEY {1}CLUSTERED (", tableName, clusteredIndex ? string.Empty : "NON" );
 
                 int numOfKeys = table.PrimaryKey.Length;

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlTableCreator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlTableCreator.cs
@@ -63,8 +63,8 @@ namespace Serilog.Sinks.MSSqlServer
             // primary keys
             if (hasPrimaryKey)
             {
-                var clusteredIndex = (bool)table.PrimaryKey[0].ExtendedProperties["clusteredIndex"];
-                sql.AppendFormat(" CONSTRAINT [PK_{0}] PRIMARY KEY {1}CLUSTERED (", tableName, clusteredIndex ? string.Empty : "NON" );
+                var NonClusteredIndex = (bool)table.PrimaryKey[0].ExtendedProperties["NonClusteredIndex"];
+                sql.AppendFormat(" CONSTRAINT [PK_{0}] PRIMARY KEY {1}CLUSTERED (", tableName, NonClusteredIndex ? "NON" : string.Empty);
 
                 int numOfKeys = table.PrimaryKey.Length;
                 i = 1;

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlTableCreator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlTableCreator.cs
@@ -11,17 +11,12 @@ namespace Serilog.Sinks.MSSqlServer
         private string _tableName;
         private string _schemaName;
 
-        #region Constructor
-
         public SqlTableCreator(string connectionString, string schemaName)
         {
             _schemaName = schemaName;
             _connectionString = connectionString;
         }
 
-        #endregion
-
-        #region Instance Methods				
         public int CreateTable(DataTable table)
         {
             if (table == null) return 0;
@@ -40,9 +35,6 @@ namespace Serilog.Sinks.MSSqlServer
 
             }
         }
-        #endregion
-
-        #region Static Methods
 
         private static string GetSqlFromDataTable(string tableName, DataTable table, string schema)
         {
@@ -52,22 +44,28 @@ namespace Serilog.Sinks.MSSqlServer
             sql.AppendFormat(" CREATE TABLE [{0}].[{1}] ( ", schema, tableName);
 
             // columns
+            bool hasPrimaryKey = false;
+            bool clusteredIndex = true;
             int numOfColumns = table.Columns.Count;
             int i = 1;
             foreach (DataColumn column in table.Columns)
             {
                 sql.AppendFormat("[{0}] {1}", column.ColumnName, SqlGetType(column));
                 if (column.ColumnName.ToUpper().Equals("ID") || column.AutoIncrement)
+                {
+                    hasPrimaryKey = true;
+                    clusteredIndex = (bool)column.ExtendedProperties["clusteredIndex"];
                     sql.Append(" IDENTITY(1,1) ");
+                }
                 if (numOfColumns > i)
                     sql.AppendFormat(", ");
                 i++;
             }
 
             // primary keys
-            if (table.PrimaryKey.Length > 0)
+            if (hasPrimaryKey)
             {
-                sql.AppendFormat(" CONSTRAINT [PK_{0}] PRIMARY KEY CLUSTERED (", tableName);
+                sql.AppendFormat(" CONSTRAINT [PK_{0}] PRIMARY KEY {1}CLUSTERED (", tableName, clusteredIndex ? string.Empty : "NON" );
 
                 int numOfKeys = table.PrimaryKey.Length;
                 i = 1;
@@ -155,7 +153,6 @@ namespace Serilog.Sinks.MSSqlServer
             return SqlGetType(column.DataType, column.MaxLength, 10, 2, column.AllowDBNull);
         }
 
-        #endregion
     }
 
 }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/StandardColumn.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/StandardColumn.cs
@@ -6,6 +6,11 @@
     public enum StandardColumn
     {
         /// <summary>
+        /// The optional primary key
+        /// </summary>
+        Id,
+
+        /// <summary>
         /// The message rendered with the template given the properties associated with the event.
         /// </summary>
         Message,


### PR DESCRIPTION
Fixes #69:
- Added `Id` to the `StandardColumn` enum
- `Id` is now part of the `ColumnOptions.Store` collection by default
- `Id` can be removed from the collection
- `Id` adds `BigInt` and `NonClusteredIndex` properties, default false for compatibility
- `NonClusteredIndex` property is on the `CommonColumnOptions` class to prep for #81

README:
- Documented various `Id` options
- Added a note about considering batch size and timeout
- Documented permissions since I reviewed recently, fixes #135 
- Other minor corrections and cleanup

Other:
- Fixed a couple older undiscovered bugs that were masked by a fluke in the way unit tests are designed (some tests use the same table name so they assert against tables created by earlier tests, not their own test scenarios). I will open an issue on that and assign it to myself.
