### PR TITLE
added unit tests for Id column options

### DIFF
--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlTableCreator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlTableCreator.cs
@@ -76,9 +76,9 @@ namespace Serilog.Sinks.MSSqlServer
 
                     i++;
                 }
-                sql.Append("))");
+                sql.Append(")");
             }
-            sql.AppendLine(" END");
+            sql.AppendLine(") END");
             return sql.ToString();
         }
 

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Microsoft.Extensions.Configuration/ConfigurationExtensions.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Microsoft.Extensions.Configuration/ConfigurationExtensions.cs
@@ -5,11 +5,12 @@ using Dapper;
 using Xunit;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
+using System;
 
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Collection("LogTest")]
-    public class ConfigurationExtensions
+    public class ConfigurationExtensions : IDisposable
     {
         static string ConnectionStringName = "NamedConnection";
         static string ColumnOptionsSection = "CustomColumnNames";
@@ -45,7 +46,6 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             // should not throw
 
             Log.CloseAndFlush();
-            DatabaseFixture.DropTable();
         }
 
         [Fact]
@@ -78,7 +78,10 @@ namespace Serilog.Sinks.MSSqlServer.Tests
 
                 infoSchema.Should().Contain(columns => columns.ColumnName == "Id");
             }
+        }
 
+        public void Dispose()
+        {
             DatabaseFixture.DropTable();
         }
     }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/CustomStandardColumnNames.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/CustomStandardColumnNames.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
-using System.Data.SqlTypes;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Dapper;
@@ -12,7 +10,7 @@ using FluentAssertions;
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Collection("LogTest")]
-    public class CustomStandardColumnNames
+    public class CustomStandardColumnNames : IDisposable
     {
         [Fact]
         public void CustomIdColumn()
@@ -41,8 +39,6 @@ namespace Serilog.Sinks.MSSqlServer.Tests
                 var isIdentity = conn.Query<IdentityQuery>($"SELECT COLUMNPROPERTY(object_id('{DatabaseFixture.LogTableName}'), '{customIdName}', 'IsIdentity') AS IsIdentity");
                 isIdentity.Should().Contain(i => i.IsIdentity == 1);
             }
-
-            DatabaseFixture.DropTable();
         }
 
         internal class IdentityQuery
@@ -76,8 +72,6 @@ namespace Serilog.Sinks.MSSqlServer.Tests
                 var isIdentity = conn.Query<IdentityQuery>($"SELECT COLUMNPROPERTY(object_id('{DatabaseFixture.LogTableName}'), '{idColumnName}', 'IsIdentity') AS IsIdentity");
                 isIdentity.Should().Contain(i => i.IsIdentity == 1);
             }
-
-            DatabaseFixture.DropTable();
         }
 
         [Fact]
@@ -111,8 +105,6 @@ namespace Serilog.Sinks.MSSqlServer.Tests
 
                 infoSchema.Should().Contain(columns => columns.ColumnName == "Id");
             }
-
-            DatabaseFixture.DropTable();
         }
 
         [Fact]
@@ -137,8 +129,6 @@ namespace Serilog.Sinks.MSSqlServer.Tests
                     infoSchema.Should().Contain(columns => columns.ColumnName == column);
                 }
             }
-
-            DatabaseFixture.DropTable();
         }
 
         [Fact]
@@ -178,8 +168,6 @@ namespace Serilog.Sinks.MSSqlServer.Tests
 
                 logEvents.Should().Contain(e => e.CustomMessage.Contains(loggingInformationMessage));
             }
-
-            DatabaseFixture.DropTable();
         }
 
         [Fact]
@@ -212,8 +200,6 @@ namespace Serilog.Sinks.MSSqlServer.Tests
 
                 logEvents.Should().Contain(e => e.Message.Contains(loggingInformationMessage));
             }
-
-            DatabaseFixture.DropTable();
         }
 
         [Fact]
@@ -253,8 +239,6 @@ namespace Serilog.Sinks.MSSqlServer.Tests
 
                 logEvents.Should().Contain(e => e.CustomMessage.Contains(loggingInformationMessage));
             }
-
-            DatabaseFixture.DropTable();
         }
 
         [Fact]
@@ -285,7 +269,10 @@ namespace Serilog.Sinks.MSSqlServer.Tests
 
                 logEvents.Should().Contain(e => e.Message.Contains(loggingInformationMessage));
             }
+        }
 
+        public void Dispose()
+        {
             DatabaseFixture.DropTable();
         }
     }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/DatabaseFixture.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/DatabaseFixture.cs
@@ -84,6 +84,6 @@ DROP DATABASE [{Database}]
         }
     }
 
-    [CollectionDefinition("LogTest")]
+    [CollectionDefinition("LogTest", DisableParallelization = true)]
     public class PatientSecureFixtureCollection : ICollectionFixture<DatabaseFixture> { }
 }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/InfoSchema.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/InfoSchema.cs
@@ -3,5 +3,6 @@ namespace Serilog.Sinks.MSSqlServer.Tests
     public class InfoSchema
     {
         public string ColumnName { get; set; }
+        public string DataType { get; set; }
     }
 }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/LevelAsEnum.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/LevelAsEnum.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Data.SqlClient;
-using System.Diagnostics;
 using System.IO;
 using Dapper;
 using FluentAssertions;
@@ -10,7 +9,7 @@ using Xunit;
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Collection("LogTest")]
-    public class LevelAsEnum
+    public class LevelAsEnum : IDisposable
     {
         [Fact]
         public void CanStoreLevelAsEnum()
@@ -41,8 +40,6 @@ namespace Serilog.Sinks.MSSqlServer.Tests
 
                 logEvents.Should().Contain(e => e.Message.Contains(loggingInformationMessage) && e.Level == 2);
             }
-
-            DatabaseFixture.DropTable();
         }
 
         [Fact]
@@ -105,8 +102,6 @@ namespace Serilog.Sinks.MSSqlServer.Tests
 
                 logEvents.Should().Contain(e => e.Message.Contains(loggingInformationMessage) && e.Level == 2);
             }
-
-            DatabaseFixture.DropTable();
         }
 
         [Fact]
@@ -136,7 +131,10 @@ namespace Serilog.Sinks.MSSqlServer.Tests
 
                 logEvents.Should().Contain(e => e.Message.Contains(loggingInformationMessage) && e.Level == LogEventLevel.Information.ToString());
             }
+        }
 
+        public void Dispose()
+        {
             DatabaseFixture.DropTable();
         }
     }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/TestPropertiesColumnFiltering.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/TestPropertiesColumnFiltering.cs
@@ -1,12 +1,13 @@
 ﻿using Dapper;
 using FluentAssertions;
+using System;
 using System.Data.SqlClient;
 using Xunit;
 
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Collection("LogTest")]
-    public class TestPropertiesColumnFiltering
+    public class TestPropertiesColumnFiltering : IDisposable
     {
         internal class PropertiesColumns
         {
@@ -46,8 +47,6 @@ namespace Serilog.Sinks.MSSqlServer.Tests
                 logEvents.Should().Contain(e => e.Properties.Contains("AValue"));
                 logEvents.Should().NotContain(e => e.Properties.Contains("BValue"));
             }
-
-            DatabaseFixture.DropTable();
         }
 
         [Fact]
@@ -83,7 +82,10 @@ namespace Serilog.Sinks.MSSqlServer.Tests
                 logEvents.Should().Contain(e => e.Properties.Contains("AValue"));
                 logEvents.Should().NotContain(e => e.Properties.Contains("BValue"));
             }
+        }
 
+        public void Dispose()
+        {
             DatabaseFixture.DropTable();
         }
     }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/TestTriggersOnLogTable.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/TestTriggersOnLogTable.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Collection("LogTest")]
-    public class TestTriggersOnLogTable
+    public class TestTriggersOnLogTable : IDisposable
     {
         [Fact]
         public void TestTriggerOnLogTableFire()
@@ -38,8 +38,6 @@ namespace Serilog.Sinks.MSSqlServer.Tests
 
                 logTriggerEvents.Should().NotBeNullOrEmpty();
             }
-
-            DropTables();
         }
 
         [Fact]
@@ -72,8 +70,6 @@ namespace Serilog.Sinks.MSSqlServer.Tests
 
                 logTriggerEvents.Should().BeEmpty();
             }
-
-            DropTables();
         }
 
         [Fact]
@@ -103,8 +99,6 @@ namespace Serilog.Sinks.MSSqlServer.Tests
 
                 logTriggerEvents.Should().NotBeNullOrEmpty();
             }
-
-            DropTables();
         }
 
         [Fact]        
@@ -148,7 +142,7 @@ END");
             }
         }
 
-        private void DropTables()
+        public void Dispose()
         {
             DatabaseFixture.DropTable();
             DatabaseFixture.DropTable(logTriggerTableName);


### PR DESCRIPTION
- adds unit tests around new `Id` features (column can be removed, non-clustered indexing, `bigint` type)
- changes unit test cleanup to use `Dispose`
- fixes a parenthesis bug with auto-create when `Id` column is removed