### PR TITLE
XML config parity with JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A Serilog sink that writes events to Microsoft SQL Server. This sink will write 
 
 ## Sink Configuration Options
 
-The sink can be configured completely through code, by using configuration files (or other types of configuration providers), a combination of both, or by using the various Serilog configuration packages.
+The sink can be configured completely through code, by using configuration files (or other types of configuration providers), a combination of both, or by using the various Serilog configuration packages. There are two configuration considerations: configuring the sink itself, and configuring the table used by the sink. The sink is configured with a typical Serilog `WriteTo` configuration method (or `AuditTo`, or similar variations). The table is configured with an optional `ColumnOptions` object passed to the configuration method.
 
 All sink configuration methods accept the following parameters, though not necessarily in this order. Use of named parameters is strongly recommended.
 
@@ -35,7 +35,6 @@ All sink configuration methods accept the following parameters, though not neces
 * `period`
 * `formatProvider`
 
-
 ### Basic Parameters
 
 At minimum, `connectionString` and `tableName` are required. If you are using an external configuration source such as an XML file or JSON file, you can use a named connection string instead of providing the full "raw" connection string.
@@ -43,6 +42,8 @@ At minimum, `connectionString` and `tableName` are required. If you are using an
 If `schemaName` is omitted, the default is `dbo`.
 
 If `autoCreateSqlTable` is `true`, the sink will create the table if a table by that name doesn't exist. It will also create the schema if no schema by that name exists. The account connecting to SQL Server will need adequate permissions to create a table (see the Permissions section of the [Table Definition](#table-definition) topic).
+
+Table configuration with the optional `ColumnOptions` object is a lengthy subject discussed in the [ColumnOptions Object](#columnoptions-object) topic and other related topics.
 
 Like other sinks, `restrictedToMinimumLevel` controls the `LogEventLevel` messages that are processed by this sink.
 
@@ -54,7 +55,7 @@ Refer to the Serilog Wiki's explanation of [Format Providers](https://github.com
 
 ### Code-Only (any .NET target)
 
-All sink features are configurable from code. Here is a typical example that works the same way for any .NET target:
+All sink features are configurable from code. Here is a typical example that works the same way for any .NET target. This example configures the sink itself as well as table features.
 
 ```csharp
 var logDB = @"Server=...";
@@ -77,7 +78,7 @@ var log = new LoggerConfiguration()
 
 ### Code + External (.NET Standard)
 
-.NET Standard projects can build (or inject) a configuration object using _Microsoft.Extensions.Configuration_ and pass it to the sink's configuration method. If provided, the settings of a `ColumnOptions` object created in code are treated as a baseline which is then updated from the external configuration data. External configuration syntax is discussed later.
+.NET Standard projects can build (or inject) a configuration object using _Microsoft.Extensions.Configuration_ and pass it to the sink's configuration method. If provided, the settings of a `ColumnOptions` object created in code are treated as a baseline which is then updated from the external configuration data. See the [External Configuration Syntax](#external-configuration-syntax) topic for details.
 
 ```csharp
 var appSettings = new ConfigurationBuilder()
@@ -101,19 +102,21 @@ var log = new LoggerConfiguration()
 
 ### Code + External (.NET Framework)
 
-Newer .NET Framework projects (4.6.1+ compliant with .NET Standard) should use the _Microsoft.Extensions.Configuration_ approach as shown above, if possible. Older .NET Framework applications can load certain configuration options from an XML configuration file such as `app.config` or `web.config`. The sink configuration method automatically checks `ConfigurationManager`, so there is no code to show (it would look the same as the code-only approach shown earlier). External configuration syntax is discussed later.
+.NET Framework applications can load `ColumnOptions` table configuration from an XML configuration file such as `app.config` or `web.config`. The sink configuration method automatically checks `ConfigurationManager`, so there is no code to show, and no additional packages are required. See the [External Configuration Syntax](#external-configuration-syntax) topic for details. 
+
+(Settings via `ConfigurationManager` is currently not available to .NET Core applications. Even though Microsoft added these classes to .NET Core 2.0, it was not part of the .NET Standard 2.0 API specification which takes precedence when a .NET Core application references this NuGet package.)
 
 ### External using _Serilog.Settings.Configuration_
 
 _Requires configuration package version [**3.0.0**](https://www.nuget.org/packages/Serilog.Settings.Configuration/3.0.0) or newer._
 
-.NET Standard projects can call `ReadFrom.Configuration()` to configure Serilog using the [_Serilog.Settings.Configuration_](https://github.com/serilog/serilog-settings-configuration) package. This will apply configuration parameters from all application configuration sources (not only `appsettings.json` as shown here, but any other valid `IConfiguration` source). All features except the property filtering predicate are supported by this package. External configuration syntax is discussed later.
+.NET Standard projects can call `ReadFrom.Configuration()` to configure Serilog using the [_Serilog.Settings.Configuration_](https://github.com/serilog/serilog-settings-configuration) package. This will apply configuration parameters from all application configuration sources (not only `appsettings.json` as shown here, but any other valid `IConfiguration` source). This package can configure the sink itsef as well as `ColumnOptions` table features. See the [External Configuration Syntax](#external-configuration-syntax) topic for details.
 
 _NOTE:_ Although the configuration package can support many configuration sources (thanks to the extensions in the underlying Microsoft packages), for simplicity this documentation differentiates this from the .NET Framework-style XML configuration by collectively referring to this as JSON configuration, since that is the most popular usage by far. Support for the many other configuration sources is implicit.
 
 ### External using _Serilog.Settings.AppSettings_
 
-.NET Framework and .NET Standard projects can use XML configuration by calling `ReadFrom.AppSettings()` using the [_Serilog.Settings.AppSettings_](https://github.com/serilog/serilog-settings-appsettings) package. This will apply configuration parameters from the project's `app.config` or `web.config` file. When using XML configuration, this is much more flexible than relying on the internal `ConfigurationManager` support because the package is able to match parameters on the configuration method, as shown below. External configuration syntax is discussed later.
+.NET Framework and .NET Standard projects can configure the sink from XML configuration by calling `ReadFrom.AppSettings()` using the [_Serilog.Settings.AppSettings_](https://github.com/serilog/serilog-settings-appsettings) package. This will apply configuration parameters from the project's `app.config` or `web.config` file. This is independent of configuring `ColumnOptions` from external XML files. See the [External Configuration Syntax](#external-configuration-syntax) topic for details.
 
 ## Audit Sink Configuration
 
@@ -398,7 +401,9 @@ var log = new LoggerConfiguration()
 
 In this example, when a log event contains any of the properties `UserName`, `UserId`, and `RequestUri`, the property values would be written to the corresponding columns. The property names must match exactly (case-insensitive).
 
-Unlike previous versions of the sink, Standard Column names are not reserved. If you remove the `Id` Standard Column from the `ColumnOptions.Store` list, you are free to create a new custom column called `Id` which the sink will treat like any other custom column fully under your control. Also, .NET `System` data types and `DataColumn` objects are not used for configuration. 
+Unlike previous versions of the sink, Standard Column names are not reserved. If you remove the `Id` Standard Column from the `ColumnOptions.Store` list, you are free to create a new custom column called `Id` which the sink will treat like any other custom column fully under your control.
+
+Note the use of the `SqlDbType` enumerations for specifying `DataType`. Unlike previous versions of the sink, .NET `System` data types and `DataColumn` objects are no longer used for custom column definition. 
 
 ### Excluding redundant data
 
@@ -410,17 +415,17 @@ Standard Columns are always excluded from the XML `Properties` column  but Stand
 
 ## External Configuration Syntax
 
-Projects targeting the .NET Framework automatically have support for XML-based configuration (either `app.config` or `web.config`) of `ColumnOptions` settings, and the _Serilog.Settings.AppSettings_ package adds XML-based configuration of sink arguments.
+Projects targeting the .NET Framework automatically have support for XML-based configuration (either `app.config` or `web.config`) of `ColumnOptions` table definition, and the _Serilog.Settings.AppSettings_ package adds XML-based configuration of sink arguments.
 
-Projects targeting .NET Standard can apply configuration-driven sink setup and `ColumnOptions` settings using the _Serilog.Settings.Configuration_ (SSC) package. It supports any of the configuration sources supported by the underlying _Microsoft.Extensions.Configuration_ (MEC) packages. JSON is the most common, but other sources include environment variables, command lines, Azure Key Vault, XML, and more.  
+Projects targeting .NET Standard can apply configuration-driven sink setup and `ColumnOptions` settings using the _Serilog.Settings.Configuration_ package. It supports any of the configuration sources supported by the underlying _Microsoft.Extensions.Configuration_ packages. JSON is the most common, but other sources include environment variables, command lines, Azure Key Vault, XML, and more.  
 
-All properties of the `ColumnOptions` class are configurable except the `Properties.PropertyFilter` predicate expression. In most cases configuration keynames match the class property names, but there are some exceptions. For example, because `PrimaryKey` is a `SqlColumn` object reference when configured through code, external configuration uses a `primaryKeyColumnName` setting to identify the primary key by name.
+All properties of the `ColumnOptions` class are configurable except the `Properties.PropertyFilter` predicate expression, and all elements and lists shown are optional. In most cases configuration keynames match the class property names, but there are some exceptions. For example, because `PrimaryKey` is a `SqlColumn` object reference when configured through code, external configuration uses a `primaryKeyColumnName` setting to identify the primary key by name.
 
-All `ColumnOptions` elements and lists are optional. Some settings or properties shown are mutually exclusive and are listed for documentation purposes -- these do not necessarily reflect real-world configurations that can be copy-pasted as-is.
+Custom columns and the stand-alone Standard Column entries all support the same general column properties (`ColumnName`, `DataType`, etc) listed in the [SqlColumn Objects](#sqlcolumn-objects) topic. The following sections documenting configuration syntax omit many of these properties for brevity.
 
-Custom columns and the stand-alone Standard Column entires all support the same general column properties (`ColumnName`, `DataType`, etc) listed in thec [SqlColumn Objects](#sqlcolumn-objects) topic. The samples omit many of these properties for brevity.
+If you combine external configuration with configuration through code, external configuration changes will be applied in addition to a `ColumnOptions` object you provide through code (external configuration "overwrites" properties defined in configuration, but properties only defined through code are preserved).
 
-If you combine external configuration with configuration through code, external configuration changes will be applied in addition to any `ColumnOptions` object you provide through code.
+Some settings or properties shown are mutually exclusive and are listed for documentation purposes -- these do not necessarily reflect real-world configurations that can be copy-pasted as-is.
 
 ### JSON: .NET Standard configuration
 
@@ -441,7 +446,7 @@ Keys and values are not case-sensitive. This is an example of configuring the si
             "restrictedToMinimumLevel": "Warning",
             "batchPostingLimit": 1000,
             "period": 30,
-            "columnOptionsSection": { ... }
+            "columnOptionsSection": { . . . }
         } 
       }
     ]
@@ -579,7 +584,7 @@ When you exit an application running in debug mode under Visual Studio, normal s
 
 ### Try a `dev` package
 
-If you're reading about a feature that doesn't seem to work, check whether you're reading the docs for the `mast` branch or the `dev` branch -- most Serilog repositories are configured to use the `dev` branch by default. If you see something interesting only described by the `dev` branch documentation, you'll have to reference a `dev`-versioned package. The repository automatically generates a new `dev` package whenever code-related changes are merged.
+If you're reading about a feature that doesn't seem to work, check whether you're reading the docs for the `master` branch or the `dev` branch -- most Serilog repositories are configured to use the `dev` branch by default. If you see something interesting only described by the `dev` branch documentation, you'll have to reference a `dev`-versioned package. The repository automatically generates a new `dev` package whenever code-related changes are merged.
 
 ### Are you really using this sink?
 
@@ -643,4 +648,4 @@ Feature | Notes
 `Id.BigInt` | Use `Id.DataType = SqlDb.BigInt` instead. (The `BigInt` property was only available in dev packages).
 `Binary` and `VarBinary` | Due to the way Serilog represents property data internally, it isn't possible for the sink to access property data as a byte array, so the sink can't write to these column types. 
 
-Deprecated features are still available, but they are marked with the `[Obsolete]` attribute (which results in a compiler warning in your project) and will be removed in a future release. You should switch to the replacement implementations as soon as possible. Where possible, internally these are converted to the replacement implementation so that they only exist at the configuration level.
+Most deprecated features are still available, but they are marked with the `[Obsolete]` attribute (which results in a compiler warning in your project) and will be removed in a future release. You should switch to the replacement implementations as soon as possible. Where possible, internally these are converted to the replacement implementation so that they only exist at the configuration level.

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/ColumnCollection.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/ColumnCollection.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.ComponentModel;
 using System.Configuration;
 
 // Disable XML comment warnings for internal config classes which are required to have public members

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/LoggerConfigurationMSSqlServerExtensions.cs
@@ -29,6 +29,11 @@ namespace Serilog
     public static class LoggerConfigurationMSSqlServerExtensions
     {
         /// <summary>
+        /// The configuration section name for app.config or web.config configuration files.
+        /// </summary>
+        public static string AppConfigSectionName = "MSSqlServerSettingsSection";
+
+        /// <summary>
         /// Adds a sink that writes log events to a table in a MSSqlServer database.
         /// Create a database and execute the table creation script found here
         /// https://gist.github.com/mivano/10429656
@@ -63,8 +68,8 @@ namespace Serilog
 
             var defaultedPeriod = period ?? MSSqlServerSink.DefaultPeriod;
 
-            if (ConfigurationManager.GetSection("MSSqlServerSettingsSection") is MSSqlServerConfigurationSection serviceConfigSection)
-                ConfigureColumnOptions(serviceConfigSection, columnOptions);
+            if (ConfigurationManager.GetSection(AppConfigSectionName) is MSSqlServerConfigurationSection serviceConfigSection)
+                columnOptions = ConfigureColumnOptions(serviceConfigSection, columnOptions);
 
             connectionString = GetConnectionString(connectionString);
 
@@ -109,8 +114,8 @@ namespace Serilog
         {
             if (loggerAuditSinkConfiguration == null) throw new ArgumentNullException("loggerAuditSinkConfiguration");
 
-            if (ConfigurationManager.GetSection("MSSqlServerSettingsSection") is MSSqlServerConfigurationSection serviceConfigSection)
-                ConfigureColumnOptions(serviceConfigSection, columnOptions);
+            if (ConfigurationManager.GetSection(AppConfigSectionName) is MSSqlServerConfigurationSection serviceConfigSection)
+                columnOptions = ConfigureColumnOptions(serviceConfigSection, columnOptions);
 
             connectionString = GetConnectionString(connectionString);
 
@@ -156,29 +161,139 @@ namespace Serilog
         /// <summary>
         /// Populate ColumnOptions properties and collections from app config
         /// </summary>
-        private static void ConfigureColumnOptions(MSSqlServerConfigurationSection serviceConfigSection, ColumnOptions columnOptions)
+        private static ColumnOptions ConfigureColumnOptions(MSSqlServerConfigurationSection config, ColumnOptions columnOptions)
         {
-            if (serviceConfigSection.Columns.Count > 0)
-            {
-                if (columnOptions == null)
-                    columnOptions = new ColumnOptions();
+            var opts = columnOptions ?? new ColumnOptions();
 
-                AddAdditionalColumns(serviceConfigSection, columnOptions);
+            AddRmoveStandardColumns();
+            AddAdditionalColumns();
+            ReadStandardColumns();
+            ReadMiscColumnOptions();
+
+            return opts;
+
+            void AddRmoveStandardColumns()
+            {
+                // add standard columns
+                if (config.AddStandardColumns.Count > 0)
+                {
+                    foreach (StandardColumnConfig col in config.AddStandardColumns)
+                    {
+                        if (Enum.TryParse(col.Name, ignoreCase: true, result: out StandardColumn stdcol)
+                            && !opts.Store.Contains(stdcol))
+                            opts.Store.Add(stdcol);
+                    }
+                }
+
+                // remove standard columns
+                if (config.RemoveStandardColumns.Count > 0)
+                {
+                    foreach (StandardColumnConfig col in config.RemoveStandardColumns)
+                    {
+                        if (Enum.TryParse(col.Name, ignoreCase: true, result: out StandardColumn stdcol)
+                            && opts.Store.Contains(stdcol))
+                            opts.Store.Remove(stdcol);
+                    }
+                }
             }
-        }
 
-        /// <summary>
-        /// Converts XML Column nodes to SqlColumn objects and adds them to
-        /// the AdditionalColumns collection.
-        /// </summary>
-        private static void AddAdditionalColumns(MSSqlServerConfigurationSection serviceConfigSection, ColumnOptions columnOptions)
-        {
-            foreach (ColumnConfig c in serviceConfigSection.Columns)
+            void AddAdditionalColumns()
             {
-                if (columnOptions.AdditionalColumns == null)
-                    columnOptions.AdditionalColumns = new Collection<SqlColumn>();
+                if (config.Columns.Count > 0)
+                {
+                    foreach (ColumnConfig c in config.Columns)
+                    {
+                        if(!string.IsNullOrWhiteSpace(c.ColumnName))
+                        {
+                            if (opts.AdditionalColumns == null)
+                                opts.AdditionalColumns = new Collection<SqlColumn>();
 
-                columnOptions.AdditionalColumns.Add(c.AsSqlColumn());
+                            opts.AdditionalColumns.Add(c.AsSqlColumn());
+                        }
+                    }
+
+                }
+            }
+
+            void ReadStandardColumns()
+            {
+                SetCommonColumnOptions(config.Exception, opts.Exception);
+                SetCommonColumnOptions(config.Id, opts.Id);
+                SetCommonColumnOptions(config.Level, opts.Level);
+                SetCommonColumnOptions(config.LogEvent, opts.LogEvent);
+                SetCommonColumnOptions(config.Message, opts.Message);
+                SetCommonColumnOptions(config.MessageTemplate, opts.MessageTemplate);
+                SetCommonColumnOptions(config.PropertiesColumn, opts.Properties);
+                SetCommonColumnOptions(config.TimeStamp, opts.TimeStamp);
+
+                SetProperty.IfProvided<bool>(config.Level, "StoreAsEnum", (val) => opts.Level.StoreAsEnum = val);
+
+                SetProperty.IfProvided<bool>(config.LogEvent, "ExcludeStandardColumns", (val) => opts.LogEvent.ExcludeStandardColumns = val);
+                SetProperty.IfProvided<bool>(config.LogEvent, "ExcludeAdditionalProperties", (val) => opts.LogEvent.ExcludeAdditionalProperties = val);
+
+                SetProperty.IfProvided<bool>(config.PropertiesColumn, "ExcludeAdditionalProperties", (val) => opts.Properties.ExcludeAdditionalProperties = val);
+                SetProperty.IfProvided<string>(config.PropertiesColumn, "DictionaryElementName", (val) => opts.Properties.DictionaryElementName = val);
+                SetProperty.IfProvided<string>(config.PropertiesColumn, "ItemElementName", (val) => opts.Properties.ItemElementName = val);
+                SetProperty.IfProvided<bool>(config.PropertiesColumn, "OmitDictionaryContainerElement", (val) => opts.Properties.OmitDictionaryContainerElement = val);
+                SetProperty.IfProvided<bool>(config.PropertiesColumn, "OmitSequenceContainerElement", (val) => opts.Properties.OmitSequenceContainerElement = val);
+                SetProperty.IfProvided<bool>(config.PropertiesColumn, "OmitStructureContainerElement", (val) => opts.Properties.OmitStructureContainerElement = val);
+                SetProperty.IfProvided<bool>(config.PropertiesColumn, "OmitElementIfEmpty", (val) => opts.Properties.OmitElementIfEmpty = val);
+                SetProperty.IfProvided<string>(config.PropertiesColumn, "PropertyElementName", (val) => opts.Properties.PropertyElementName = val);
+                SetProperty.IfProvided<string>(config.PropertiesColumn, "RootElementName", (val) => opts.Properties.RootElementName = val);
+                SetProperty.IfProvided<string>(config.PropertiesColumn, "SequenceElementName", (val) => opts.Properties.SequenceElementName = val);
+                SetProperty.IfProvided<string>(config.PropertiesColumn, "StructureElementName", (val) => opts.Properties.StructureElementName = val);
+                SetProperty.IfProvided<bool>(config.PropertiesColumn, "UsePropertyKeyAsElementName", (val) => opts.Properties.UsePropertyKeyAsElementName = val);
+
+                SetProperty.IfProvided<bool>(config.TimeStamp, "ConvertToUtc", (val) => opts.TimeStamp.ConvertToUtc = val);
+
+                // Standard Columns are subclasses of the SqlColumn class
+                void SetCommonColumnOptions(ColumnConfig source, SqlColumn target)
+                {
+                    SetProperty.IfProvidedNotEmpty<string>(source, "ColumnName", (val) => target.ColumnName = val);
+                    SetProperty.IfProvided<string>(source, "DataType", (val) => target.SetDataTypeFromConfigString(val));
+                    SetProperty.IfProvided<bool>(source, "AllowNull", (val) => target.AllowNull = val);
+                    SetProperty.IfProvided<int>(source, "DataLength", (val) => target.DataLength = val);
+                    SetProperty.IfProvided<bool>(source, "NonClusteredIndex", (val) => target.NonClusteredIndex = val);
+                }
+            }
+
+            void ReadMiscColumnOptions()
+            {
+                SetProperty.IfProvided<bool>(config, "DisableTriggers", (val) => opts.DisableTriggers = val);
+                SetProperty.IfProvided<bool>(config, "ClusteredColumnstoreIndex", (val) => opts.ClusteredColumnstoreIndex = val);
+
+                string pkName = null;
+                SetProperty.IfProvidedNotEmpty<string>(config, "PrimaryKeyColumnName", (val) => pkName = val);
+                if (pkName != null)
+                {
+                    if (opts.ClusteredColumnstoreIndex)
+                        throw new ArgumentException("SQL Clustered Columnstore Indexes and primary key constraints are mutually exclusive.");
+
+                    foreach (var standardCol in opts.Store)
+                    {
+                        var stdColOpts = opts.GetStandardColumnOptions(standardCol);
+                        if (pkName.Equals(stdColOpts.ColumnName, StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            opts.PrimaryKey = stdColOpts;
+                            break;
+                        }
+                    }
+
+                    if (opts.PrimaryKey == null && opts.AdditionalColumns != null)
+                    {
+                        foreach (var col in opts.AdditionalColumns)
+                        {
+                            if (pkName.Equals(col.ColumnName, StringComparison.InvariantCultureIgnoreCase))
+                            {
+                                opts.PrimaryKey = col;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (opts.PrimaryKey == null)
+                        throw new ArgumentException($"Could not match the configured primary key column name \"{pkName}\" with a data column in the table.");
+                }
             }
         }
     }

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/MSSqlServerConfigurationSection.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/MSSqlServerConfigurationSection.cs
@@ -18,22 +18,123 @@ using System.Configuration;
 // Disable XML comment warnings for internal config classes which are required to have public members
 #pragma warning disable 1591
 
+// Implement all config value-type properties as strings (including enumerators).
+// The logger configuration process overlays external configuration on a ColumnOptions
+// object already configured through code. It uses value-origin checks to determine
+// whether a property value was provided from external configuration.
+
 namespace Serilog.Configuration
 {
     // Should be in the sink namespace but changing it would break existing app.config files
 
     public class MSSqlServerConfigurationSection : ConfigurationSection
     {
-        public static MSSqlServerConfigurationSection Settings { get; } = ConfigurationManager.GetSection("MSSqlServerSettings") as MSSqlServerConfigurationSection;
+        public static MSSqlServerConfigurationSection Settings
+        { get; } = ConfigurationManager.GetSection(LoggerConfigurationMSSqlServerExtensions.AppConfigSectionName) as MSSqlServerConfigurationSection;
+
+        public MSSqlServerConfigurationSection()
+        {
+            base["Level"] = new StandardColumnConfigLevel();
+        }
+
+        [ConfigurationProperty("DisableTriggers")]
+        public string DisableTriggers
+        {
+            get => (string)base["DisableTriggers"];
+            set
+            {
+                base["DisableTriggers"] = value;
+            }
+        }
+
+        [ConfigurationProperty("ClusteredColumnstoreIndex")]
+        public string ClusteredColumnstoreIndex
+        {
+            get => (string)base["ClusteredColumnstoreIndex"];
+            set
+            {
+                base["ClusteredColumnstoreIndex"] = value;
+            }
+        }
+
+        [ConfigurationProperty("PrimaryKeyColumnName")]
+        public string PrimaryKeyColumnName
+        {
+            get => (string)base["PrimaryKeyColumnName"];
+            set
+            {
+                base["PrimaryKeyColumnName"] = value;
+            }
+        }
+
+        [ConfigurationProperty("AddStandardColumns", IsDefaultCollection = false)]
+        [ConfigurationCollection(typeof(StandardColumnCollection), AddItemName = "add")]
+        public StandardColumnCollection AddStandardColumns
+        {
+            get => (StandardColumnCollection)base["AddStandardColumns"];
+        }
+
+        [ConfigurationProperty("RemoveStandardColumns", IsDefaultCollection = false)]
+        [ConfigurationCollection(typeof(StandardColumnCollection), AddItemName = "remove")]
+        public StandardColumnCollection RemoveStandardColumns
+        {
+            get => (StandardColumnCollection)base["RemoveStandardColumns"];
+        }
 
         [ConfigurationProperty("Columns", IsDefaultCollection = false)]
-        [ConfigurationCollection(typeof(ColumnCollection), AddItemName = "add", ClearItemsName = "clear", RemoveItemName = "remove")]
+        [ConfigurationCollection(typeof(ColumnCollection), AddItemName = "add")]
         public ColumnCollection Columns
         {
-            get
-            {
-                return (ColumnCollection)base["Columns"];
-            }
+            get => (ColumnCollection)base["Columns"];
+        }
+
+        [ConfigurationProperty("Exception")]
+        public StandardColumnConfigException Exception
+        {
+            get => (StandardColumnConfigException)base["Exception"];
+        }
+
+        [ConfigurationProperty("Id")]
+        public StandardColumnConfigId Id
+        {
+            get => (StandardColumnConfigId)base["Id"];
+        }
+
+        [ConfigurationProperty("Level")]
+        public StandardColumnConfigLevel Level
+        {
+            get => (StandardColumnConfigLevel)base["Level"];
+        }
+
+        [ConfigurationProperty("LogEvent")]
+        public StandardColumnConfigLogEvent LogEvent
+        {
+            get => (StandardColumnConfigLogEvent)base["LogEvent"];
+        }
+
+        [ConfigurationProperty("Message")]
+        public StandardColumnConfigMessage Message
+        {
+            get => (StandardColumnConfigMessage)base["Message"];
+        }
+
+        [ConfigurationProperty("MessageTemplate")]
+        public StandardColumnConfigMessageTemplate MessageTemplate
+        {
+            get => (StandardColumnConfigMessageTemplate)base["MessageTemplate"];
+        }
+
+        // Name changed to avoid conflict with Properties in ConfigurationElement base class
+        [ConfigurationProperty("Properties")]
+        public StandardColumnConfigProperties PropertiesColumn
+        {
+            get => (StandardColumnConfigProperties)base["Properties"];
+        }
+
+        [ConfigurationProperty("TimeStamp")]
+        public StandardColumnConfigTimeStamp TimeStamp
+        {
+            get => (StandardColumnConfigTimeStamp)base["TimeStamp"];
         }
     }
 }

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/SetPropertyValueOrigin.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/SetPropertyValueOrigin.cs
@@ -1,0 +1,30 @@
+﻿using System.Configuration;
+
+namespace Serilog.Sinks.MSSqlServer
+{
+    public static partial class SetProperty
+    {
+        // A null-check isn't possible for XML config strings; they default to an empty string and setting DefaultValue
+        // to null doesn't work because internally the ConfigurationProperty attribute changes it back to empty string.
+
+        /// <summary>
+        /// Test the underlying property collection's value-origin flag for a non-default value. Empty strings allowed.
+        /// </summary>
+        public static void IfProvided<T>(ConfigurationElement element, string propertyName, PropertySetter<T> setter)
+        {
+            var property = element.ElementInformation.Properties[propertyName];
+            if (property.ValueOrigin == PropertyValueOrigin.Default) return;
+            IfNotNull((string)property.Value, setter);
+        }
+
+        /// <summary>
+        /// Test the underlying property collection's value-origin flag for a non-default value. Empty strings allowed.
+        /// </summary>
+        public static void IfProvidedNotEmpty<T>(ConfigurationElement element, string propertyName, PropertySetter<T> setter)
+        {
+            var property = element.ElementInformation.Properties[propertyName];
+            if (property.ValueOrigin == PropertyValueOrigin.Default) return;
+            IfNotNullOrEmpty((string)property.Value, setter);
+        }
+    }
+}

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/StandardColumnCollection.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/StandardColumnCollection.cs
@@ -1,0 +1,22 @@
+﻿using System.Configuration;
+
+// Disable XML comment warnings for internal config classes which are required to have public members
+#pragma warning disable 1591
+
+namespace Serilog.Sinks.MSSqlServer
+{
+    public class StandardColumnCollection : ConfigurationElementCollection
+    {
+        protected override ConfigurationElement CreateNewElement()
+        {
+            return new StandardColumnConfig();
+        }
+
+        protected override object GetElementKey(ConfigurationElement element)
+        {
+            return ((StandardColumnConfig)element).Name;
+        }
+    }
+}
+
+#pragma warning restore 1591

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/StandardColumnConfig.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/StandardColumnConfig.cs
@@ -1,0 +1,22 @@
+﻿using System.Configuration;
+
+// Disable XML comment warnings for internal config classes which are required to have public members
+#pragma warning disable 1591
+
+namespace Serilog.Sinks.MSSqlServer
+{
+    public class StandardColumnConfig : ConfigurationElement
+    {
+        public StandardColumnConfig()
+        { }
+
+        [ConfigurationProperty("Name", IsRequired = true, IsKey = true)]
+        public string Name
+        {
+            get { return (string)this["Name"]; }
+            set { this["Name"] = value; }
+        }
+    }
+}
+
+#pragma warning restore 1591

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/StandardColumnConfigException.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/StandardColumnConfigException.cs
@@ -1,0 +1,24 @@
+﻿using System.Configuration;
+
+// Disable XML comment warnings for internal config classes which are required to have public members
+#pragma warning disable 1591
+
+namespace Serilog.Sinks.MSSqlServer
+{
+    public class StandardColumnConfigException : ColumnConfig
+    {
+        public StandardColumnConfigException() : base()
+        { }
+
+        // override to set IsRequired = false
+        [ConfigurationProperty("ColumnName", IsRequired = false, IsKey = true)]
+        public override string ColumnName
+        {
+            get => base.ColumnName;
+            set => base.ColumnName = value;
+        }
+    }
+}
+
+#pragma warning restore 1591
+

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/StandardColumnConfigId.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/StandardColumnConfigId.cs
@@ -1,0 +1,24 @@
+﻿using System.Configuration;
+
+// Disable XML comment warnings for internal config classes which are required to have public members
+#pragma warning disable 1591
+
+namespace Serilog.Sinks.MSSqlServer
+{
+    public class StandardColumnConfigId : ColumnConfig
+    {
+        public StandardColumnConfigId() : base()
+        { }
+
+        // override to set IsRequired = false
+        [ConfigurationProperty("ColumnName", IsRequired = false, IsKey = true)]
+        public override string ColumnName
+        {
+            get => base.ColumnName;
+            set => base.ColumnName = value;
+        }
+    }
+}
+
+#pragma warning restore 1591
+

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/StandardColumnConfigLevel.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/StandardColumnConfigLevel.cs
@@ -1,0 +1,35 @@
+﻿using System.Configuration;
+
+// Disable XML comment warnings for internal config classes which are required to have public members
+#pragma warning disable 1591
+
+namespace Serilog.Sinks.MSSqlServer
+{
+    public class StandardColumnConfigLevel : ColumnConfig
+    {
+        public StandardColumnConfigLevel() : base()
+        { }
+
+        // override to set IsRequired = false
+        [ConfigurationProperty("ColumnName", IsRequired = false, IsKey = true)]
+        public override string ColumnName
+        {
+            get => base.ColumnName;
+            set => base.ColumnName = value;
+        }
+
+        [ConfigurationProperty("StoreAsEnum")]
+        public string StoreAsEnum
+        {
+            get => (string)base["StoreAsEnum"];
+            set
+            {
+                base["StoreAsEnum"] = value;
+            }
+        }
+
+    }
+}
+
+#pragma warning restore 1591
+

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/StandardColumnConfigLogEvent.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/StandardColumnConfigLogEvent.cs
@@ -1,0 +1,44 @@
+﻿using System.Configuration;
+
+// Disable XML comment warnings for internal config classes which are required to have public members
+#pragma warning disable 1591
+
+namespace Serilog.Sinks.MSSqlServer
+{
+    public class StandardColumnConfigLogEvent : ColumnConfig
+    {
+        public StandardColumnConfigLogEvent() : base()
+        { }
+
+        // override to set IsRequired = false
+        [ConfigurationProperty("ColumnName", IsRequired = false, IsKey = true)]
+        public override string ColumnName
+        {
+            get => base.ColumnName;
+            set => base.ColumnName = value;
+        }
+
+        [ConfigurationProperty("ExcludeAdditionalProperties")]
+        public string ExcludeAdditionalProperties
+        {
+            get => (string)base["ExcludeAdditionalProperties"];
+            set
+            {
+                base["ExcludeAdditionalProperties"] = value;
+            }
+        }
+
+        [ConfigurationProperty("ExcludeStandardColumns")]
+        public string ExcludeStandardColumns
+        {
+            get => (string)base["ExcludeStandardColumns"];
+            set
+            {
+                base["ExcludeStandardColumns"] = value;
+            }
+        }
+    }
+}
+
+#pragma warning restore 1591
+

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/StandardColumnConfigMessage.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/StandardColumnConfigMessage.cs
@@ -1,0 +1,24 @@
+﻿using System.Configuration;
+
+// Disable XML comment warnings for internal config classes which are required to have public members
+#pragma warning disable 1591
+
+namespace Serilog.Sinks.MSSqlServer
+{
+    public class StandardColumnConfigMessage : ColumnConfig
+    {
+        public StandardColumnConfigMessage() : base()
+        { }
+
+        // override to set IsRequired = false
+        [ConfigurationProperty("ColumnName", IsRequired = false, IsKey = true)]
+        public override string ColumnName
+        {
+            get => base.ColumnName;
+            set => base.ColumnName = value;
+        }
+    }
+}
+
+#pragma warning restore 1591
+

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/StandardColumnConfigMessageTemplate.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/StandardColumnConfigMessageTemplate.cs
@@ -1,0 +1,24 @@
+﻿using System.Configuration;
+
+// Disable XML comment warnings for internal config classes which are required to have public members
+#pragma warning disable 1591
+
+namespace Serilog.Sinks.MSSqlServer
+{
+    public class StandardColumnConfigMessageTemplate : ColumnConfig
+    {
+        public StandardColumnConfigMessageTemplate() : base()
+        { }
+
+        // override to set IsRequired = false
+        [ConfigurationProperty("ColumnName", IsRequired = false, IsKey = true)]
+        public override string ColumnName
+        {
+            get => base.ColumnName;
+            set => base.ColumnName = value;
+        }
+    }
+}
+
+#pragma warning restore 1591
+

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/StandardColumnConfigProperties.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/StandardColumnConfigProperties.cs
@@ -1,0 +1,145 @@
+﻿using System.Configuration;
+
+// Disable XML comment warnings for internal config classes which are required to have public members
+#pragma warning disable 1591
+
+namespace Serilog.Sinks.MSSqlServer
+{
+    public class StandardColumnConfigProperties : ColumnConfig
+    {
+        public StandardColumnConfigProperties() : base()
+        { }
+
+        // override to set IsRequired = false
+        [ConfigurationProperty("ColumnName", IsRequired = false, IsKey = true)]
+        public override string ColumnName
+        {
+            get => base.ColumnName;
+            set => base.ColumnName = value;
+        }
+
+        [ConfigurationProperty("ExcludeAdditionalProperties")]
+        public string ExcludeAdditionalProperties
+        {
+            get => (string)base["ExcludeAdditionalProperties"];
+            set
+            {
+                base["ExcludeAdditionalProperties"] = value;
+            }
+        }
+
+        [ConfigurationProperty("DictionaryElementName")]
+        public string DictionaryElementName
+        {
+            get => (string)base["DictionaryElementName"];
+            set
+            {
+                base["DictionaryElementName"] = value;
+            }
+        }
+
+        [ConfigurationProperty("ItemElementName")]
+        public string ItemElementName
+        {
+            get => (string)base["ItemElementName"];
+            set
+            {
+                base["ItemElementName"] = value;
+            }
+        }
+
+        [ConfigurationProperty("OmitDictionaryContainerElement")]
+        public string OmitDictionaryContainerElement
+        {
+            get => (string)base["OmitDictionaryContainerElement"];
+            set
+            {
+                base["OmitDictionaryContainerElement"] = value;
+            }
+        }
+
+        [ConfigurationProperty("OmitSequenceContainerElement")]
+        public string OmitSequenceContainerElement
+        {
+            get => (string)base["OmitSequenceContainerElement"];
+            set
+            {
+                base["OmitSequenceContainerElement"] = value;
+            }
+        }
+
+        [ConfigurationProperty("OmitStructureContainerElement")]
+        public string OmitStructureContainerElement
+        {
+            get => (string)base["OmitStructureContainerElement"];
+            set
+            {
+                base["OmitStructureContainerElement"] = value;
+            }
+        }
+
+        [ConfigurationProperty("OmitElementIfEmpty")]
+        public string OmitElementIfEmpty
+        {
+            get => (string)base["OmitElementIfEmpty"];
+            set
+            {
+                base["OmitElementIfEmpty"] = value;
+            }
+        }
+
+        [ConfigurationProperty("PropertyElementName")]
+        public string PropertyElementName
+        {
+            get => (string)base["PropertyElementName"];
+            set
+            {
+                base["PropertyElementName"] = value;
+            }
+        }
+
+        [ConfigurationProperty("RootElementName")]
+        public string RootElementName
+        {
+            get => (string)base["RootElementName"];
+            set
+            {
+                base["RootElementName"] = value;
+            }
+        }
+
+        [ConfigurationProperty("SequenceElementName")]
+        public string SequenceElementName
+        {
+            get => (string)base["SequenceElementName"];
+            set
+            {
+                base["SequenceElementName"] = value;
+            }
+        }
+
+        [ConfigurationProperty("StructureElementName")]
+        public string StructureElementName
+        {
+            get => (string)base["StructureElementName"];
+            set
+            {
+                base["StructureElementName"] = value;
+            }
+        }
+
+        [ConfigurationProperty("UsePropertyKeyAsElementName")]
+        public string UsePropertyKeyAsElementName
+        {
+            get => (string)base["UsePropertyKeyAsElementName"];
+            set
+            {
+                base["UsePropertyKeyAsElementName"] = value;
+            }
+        }
+
+    }
+}
+
+#pragma warning restore 1591
+

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/StandardColumnConfigTimeStamp.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/NetFramework.ConfigurationManager/StandardColumnConfigTimeStamp.cs
@@ -1,0 +1,35 @@
+﻿using System.Configuration;
+
+// Disable XML comment warnings for internal config classes which are required to have public members
+#pragma warning disable 1591
+
+namespace Serilog.Sinks.MSSqlServer
+{
+    public class StandardColumnConfigTimeStamp : ColumnConfig
+    {
+        public StandardColumnConfigTimeStamp() : base()
+        { }
+
+        // override to set IsRequired = false
+        [ConfigurationProperty("ColumnName", IsRequired = false, IsKey = true)]
+        public override string ColumnName
+        {
+            get => base.ColumnName;
+            set => base.ColumnName = value;
+        }
+
+        [ConfigurationProperty("ConvertToUtc")]
+        public string ConvertToUtc
+        {
+            get => (string)base["ConvertToUtc"];
+            set
+            {
+                base["ConvertToUtc"] = value;
+            }
+        }
+
+    }
+}
+
+#pragma warning restore 1591
+

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/SetProperty.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/SetProperty.cs
@@ -1,0 +1,48 @@
+﻿using System;
+
+namespace Serilog.Sinks.MSSqlServer
+{
+    /// <summary>
+    /// Helper for applying only those properties actually specified in external configuration.
+    /// </summary>
+    public static partial class SetProperty
+    {
+        // Usage:
+        // SetProperty.IfValueNotNull<bool>(stringFromConfig, (boolOutputValue) => opts.BoolProperty = boolOutputValue);
+
+        /// <summary>
+        /// Simulates passing a property-setter to an "out" argument.
+        /// </summary>
+        public delegate void PropertySetter<T>(T value);
+
+        /// <summary>
+        /// This will only set a value (execute the PropertySetter delegate) if the value is non-null.
+        /// It also converts the provided value to the requested type. This allows configuration to only
+        /// apply property changes when external configuration has actually provided a value.
+        /// </summary>
+        public static void IfNotNull<T>(string value, PropertySetter<T> setter)
+        {
+            if (value == null) return;
+            try
+            {
+                T setting = (T)Convert.ChangeType(value, typeof(T));
+                setter(setting);
+            }
+            // don't change the property if the conversion fails 
+            catch (InvalidCastException) { }
+            catch (OverflowException) { }
+        }
+
+        /// <summary>
+        /// This will only set a value (execute the PropertySetter delegate) if the value is non-null and
+        /// isn't empty or whitespace. This override is used when {T} is a string value that can't be empty.
+        /// It also converts the provided value to the requested type. This allows configuration to only
+        /// apply property changes when external configuration has actually provided a value.
+        /// </summary>
+        public static void IfNotNullOrEmpty<T>(string value, PropertySetter<T> setter)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return;
+            IfNotNull(value, setter);
+        }
+    }
+}

--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -56,4 +56,8 @@
     <Compile Include="Configuration\NetFramework.ConfigurationManager\**\*.cs" />
   </ItemGroup>
   
+  <ItemGroup>
+    <None Include="Configuration\SetProperty.cs" />
+  </ItemGroup>
+  
 </Project>


### PR DESCRIPTION
Significantly expands XML configuration support. Now, just like configuration in .NET Standard, all options can be configured except the `Properties` filter predicate (for the same reasons -- it would require Roslyn compiler overhead that isn't warranted).

fixes #80 
fixes #119 

I'll be doing a little more testing before I merge but I wanted to get the PR in the pipeline now.