### PR TITLE
Readme tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ Keys and values are not case-sensitive. This is an example of configuring the si
             "autoCreateSqlTable": true,
             "restrictedToMinimumLevel": "Warning",
             "batchPostingLimit": 1000,
-            "period": 30,
+            "period": "0.00:00:30",
             "columnOptionsSection": { . . . }
         } 
       }
@@ -490,7 +490,7 @@ As the name suggests, `columnOptionSection` is an entire configuration section i
     "removeStandardColumns": [ "MessageTemplate", "Properties" ],
     "additionalColumns": [
         { "ColumnName": "EventType", "DataType": "int", "AllowNull": false },
-        { "ColumnName": "Release", "DataType": "varchar", "DataLength": 32 }
+        { "ColumnName": "Release", "DataType": "varchar", "DataLength": 32 },
         { "ColumnName": "All_SqlColumn_Defaults",
             "DataType": "varchar",
             "AllowNull": true,


### PR DESCRIPTION
One of the example configurations in the readme sets the batching period to 30 which results in a 30 day timespan. It took me a bit to figure out thats why I wasn't getting anything logged.

Change it to 30 seconds.