### PR TITLE
Remove duplicated CreateLogger line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ var log = new LoggerConfiguration()
         columnOptions: opts,
         appConfiguration: appSettings
     ).CreateLogger();
-    .CreateLogger();
 ```
 
 ### Code + _System.Configuration_


### PR DESCRIPTION
The **CreateLogger();** is duplicated, this PR removes the second call to CreateLogger.