### PR TITLE
Overrideable formatter for LogEvent column

### DIFF
--- a/assets/CommonAssemblyInfo.cs
+++ b/assets/CommonAssemblyInfo.cs
@@ -1,5 +1,0 @@
-using System.Reflection;
-
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.1.1.1")]
-[assembly: AssemblyInformationalVersion("1.0.0")]

--- a/sample/CustomLogEventFormatterDemo/CustomLogEventFormatterDemo.csproj
+++ b/sample/CustomLogEventFormatterDemo/CustomLogEventFormatterDemo.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Serilog.Sinks.MSSqlServer\Serilog.Sinks.MSSqlServer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sample/CustomLogEventFormatterDemo/FlatLogEventFormatter.cs
+++ b/sample/CustomLogEventFormatterDemo/FlatLogEventFormatter.cs
@@ -1,0 +1,19 @@
+﻿using Serilog.Events;
+using Serilog.Formatting;
+using System.IO;
+using System.Linq;
+
+namespace CustomLogEventFormatterDemo
+{
+    public class FlatLogEventFormatter : ITextFormatter
+    {
+        public void Format(LogEvent logEvent, TextWriter output)
+        {
+            logEvent.Properties.ToList().ForEach(e =>
+                {
+                    output.Write($"{e.Key}={e.Value} ");
+                });
+            output.WriteLine();
+        }
+    }
+}

--- a/sample/CustomLogEventFormatterDemo/Program.cs
+++ b/sample/CustomLogEventFormatterDemo/Program.cs
@@ -1,0 +1,57 @@
+﻿using Serilog;
+using Serilog.Sinks.MSSqlServer;
+using System;
+using System.Threading;
+
+namespace CustomLogEventFormatterDemo
+{
+    public class Program
+    {
+        const string _connectionString = "Server=localhost;Database=LogTest;Integrated Security=SSPI;";
+        const string _schemaName = "dbo";
+        const string _tableName = "LogEvents";
+
+        static void Main()
+        {
+            var options = new ColumnOptions();
+            options.Store.Add(StandardColumn.LogEvent);
+            var customFormatter = new FlatLogEventFormatter();
+            Log.Logger = new LoggerConfiguration()
+                .WriteTo.MSSqlServer(_connectionString,
+                    _tableName,
+                    appConfiguration: null,
+                    restrictedToMinimumLevel: Serilog.Events.LogEventLevel.Verbose,
+                    batchPostingLimit: 50,
+                    period: null,
+                    formatProvider: null,
+                    autoCreateSqlTable: true,
+                    columnOptions: options,
+                    columnOptionsSection: null,
+                    schemaName: _schemaName,
+                    logEventFormatter: customFormatter)
+                .CreateLogger();
+
+            try
+            {
+                Log.Debug("Getting started");
+
+                Log.Information("Hello {Name} from thread {ThreadId}", Environment.GetEnvironmentVariable("USERNAME"), Thread.CurrentThread.ManagedThreadId);
+
+                Log.Warning("No coins remain at position {@Position}", new { Lat = 25, Long = 134 });
+
+                Fail();
+            }
+            catch (DivideByZeroException e)
+            {
+                Log.Error(e, "Division by zero");
+            }
+
+            Log.CloseAndFlush();
+        }
+
+        static void Fail()
+        {
+            throw new DivideByZeroException();
+        }
+    }
+}

--- a/serilog-sinks-mssqlserver.sln
+++ b/serilog-sinks-mssqlserver.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.16
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29806.167
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{04226074-C72F-42BC-AB02-4D70A7BAE7E1}"
 EndProject
@@ -19,6 +19,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Sinks.MSSqlServer",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Sinks.MSSqlServer.Tests", "test\Serilog.Sinks.MSSqlServer.Tests\Serilog.Sinks.MSSqlServer.Tests.csproj", "{3C2D8E01-5580-426A-BDD9-EC59CD98E618}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sample", "sample", "{AA346332-5BAF-47F1-B8FB-7600ED61265D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CustomLogEventFormatterDemo", "sample\CustomLogEventFormatterDemo\CustomLogEventFormatterDemo.csproj", "{873320F1-8F6D-45E2-A853-D321C86793EC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +37,10 @@ Global
 		{3C2D8E01-5580-426A-BDD9-EC59CD98E618}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3C2D8E01-5580-426A-BDD9-EC59CD98E618}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3C2D8E01-5580-426A-BDD9-EC59CD98E618}.Release|Any CPU.Build.0 = Release|Any CPU
+		{873320F1-8F6D-45E2-A853-D321C86793EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{873320F1-8F6D-45E2-A853-D321C86793EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{873320F1-8F6D-45E2-A853-D321C86793EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{873320F1-8F6D-45E2-A853-D321C86793EC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -40,6 +48,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{803CD13A-D54B-4CEC-A55F-E22AE3D93B3C} = {04226074-C72F-42BC-AB02-4D70A7BAE7E1}
 		{3C2D8E01-5580-426A-BDD9-EC59CD98E618} = {F02D6513-6F45-452E-85A0-41A872A2C1F8}
+		{873320F1-8F6D-45E2-A853-D321C86793EC} = {AA346332-5BAF-47F1-B8FB-7600ED61265D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AAA6BF8D-7B53-4A5F-A79A-D1B306383B45}

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/Hybrid/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/Hybrid/LoggerConfigurationMSSqlServerExtensions.cs
@@ -51,11 +51,11 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <param name="autoCreateSqlTable">Create log table with the provided name on destination sql server.</param>
         /// <param name="columnOptions">An externally-modified group of column settings</param>
         /// <param name="columnOptionsSection">A config section defining various column settings</param>
         /// <param name="schemaName">Name of the schema for the table to store the data in. The default is 'dbo'.</param>
+        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration MSSqlServer(
@@ -67,11 +67,11 @@ namespace Serilog
             int batchPostingLimit = MSSqlServerSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
-            ITextFormatter logEventFormatter = null,
             bool autoCreateSqlTable = false,
             ColumnOptions columnOptions = null,
             IConfigurationSection columnOptionsSection = null,
-            string schemaName = "dbo")
+            string schemaName = "dbo",
+            ITextFormatter logEventFormatter = null)
         {
             if (loggerConfiguration == null)
                 throw new ArgumentNullException(nameof(loggerConfiguration));
@@ -102,11 +102,10 @@ namespace Serilog
                     batchPostingLimit,
                     defaultedPeriod,
                     formatProvider,
-                    logEventFormatter,
                     autoCreateSqlTable,
                     colOpts,
-                    schemaName
-                    ),
+                    schemaName,
+                    logEventFormatter),
                 restrictedToMinimumLevel);
         }
 
@@ -119,11 +118,11 @@ namespace Serilog
         /// <param name="appConfiguration">Additional application-level configuration. Required if connectionString is a name.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <param name="autoCreateSqlTable">Create log table with the provided name on destination sql server.</param>
         /// <param name="columnOptions">An externally-modified group of column settings</param>
         /// <param name="columnOptionsSection">A config section defining various column settings</param>
         /// <param name="schemaName">Name of the schema for the table to store the data in. The default is 'dbo'.</param>
+        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration MSSqlServer(
@@ -133,11 +132,11 @@ namespace Serilog
             IConfiguration appConfiguration = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null,
-            ITextFormatter logEventFormatter = null,
             bool autoCreateSqlTable = false,
             ColumnOptions columnOptions = null,
             IConfigurationSection columnOptionsSection = null,
-            string schemaName = "dbo")
+            string schemaName = "dbo",
+            ITextFormatter logEventFormatter = null)
         {
             if (loggerAuditSinkConfiguration == null)
                 throw new ArgumentNullException(nameof(loggerAuditSinkConfiguration));
@@ -165,11 +164,10 @@ namespace Serilog
                     connStr,
                     tableName,
                     formatProvider,
-                    logEventFormatter,
                     autoCreateSqlTable,
                     colOpts,
-                    schemaName
-                    ),
+                    schemaName,
+                    logEventFormatter),
                 restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/Hybrid/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/Hybrid/LoggerConfigurationMSSqlServerExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Serilog Contributors
+﻿// Copyright 2020 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ using Serilog.Sinks.MSSqlServer;
 using Microsoft.Extensions.Configuration;
 using System.Configuration;
 using Serilog.Debugging;
+using Serilog.Formatting;
 
 // The "Hybrid" configuration system supports both Microsoft.Extensions.Configuration and System.Configuration.
 // This is necessary because .NET Framework 4.6.1+ and .NET Core 2.0+ apps support both approaches, whereas the
@@ -50,6 +51,7 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <param name="autoCreateSqlTable">Create log table with the provided name on destination sql server.</param>
         /// <param name="columnOptions">An externally-modified group of column settings</param>
         /// <param name="columnOptionsSection">A config section defining various column settings</param>
@@ -65,14 +67,14 @@ namespace Serilog
             int batchPostingLimit = MSSqlServerSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
+            ITextFormatter logEventFormatter = null,
             bool autoCreateSqlTable = false,
             ColumnOptions columnOptions = null,
             IConfigurationSection columnOptionsSection = null,
-            string schemaName = "dbo"
-            )
+            string schemaName = "dbo")
         {
-            if(loggerConfiguration == null)
-                throw new ArgumentNullException("loggerConfiguration");
+            if (loggerConfiguration == null)
+                throw new ArgumentNullException(nameof(loggerConfiguration));
 
             var defaultedPeriod = period ?? MSSqlServerSink.DefaultPeriod;
             var colOpts = columnOptions ?? new ColumnOptions();
@@ -100,6 +102,7 @@ namespace Serilog
                     batchPostingLimit,
                     defaultedPeriod,
                     formatProvider,
+                    logEventFormatter,
                     autoCreateSqlTable,
                     colOpts,
                     schemaName
@@ -116,6 +119,7 @@ namespace Serilog
         /// <param name="appConfiguration">Additional application-level configuration. Required if connectionString is a name.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <param name="autoCreateSqlTable">Create log table with the provided name on destination sql server.</param>
         /// <param name="columnOptions">An externally-modified group of column settings</param>
         /// <param name="columnOptionsSection">A config section defining various column settings</param>
@@ -129,14 +133,14 @@ namespace Serilog
             IConfiguration appConfiguration = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null,
+            ITextFormatter logEventFormatter = null,
             bool autoCreateSqlTable = false,
             ColumnOptions columnOptions = null,
             IConfigurationSection columnOptionsSection = null,
-            string schemaName = "dbo"
-            )
+            string schemaName = "dbo")
         {
-            if(loggerAuditSinkConfiguration == null)
-                throw new ArgumentNullException("loggerAuditSinkConfiguration");
+            if (loggerAuditSinkConfiguration == null)
+                throw new ArgumentNullException(nameof(loggerAuditSinkConfiguration));
 
             var colOpts = columnOptions ?? new ColumnOptions();
             var connStr = connectionString;
@@ -161,6 +165,7 @@ namespace Serilog
                     connStr,
                     tableName,
                     formatProvider,
+                    logEventFormatter,
                     autoCreateSqlTable,
                     colOpts,
                     schemaName

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationMSSqlServerExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Serilog Contributors
+﻿// Copyright 2020 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ using Serilog.Configuration;
 using Serilog.Events;
 using Serilog.Sinks.MSSqlServer;
 using Microsoft.Extensions.Configuration;
+using Serilog.Formatting;
 
 // M.E.C. support for .NET Standard 2.0 libraries.
 
@@ -41,6 +42,7 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <param name="autoCreateSqlTable">Create log table with the provided name on destination sql server.</param>
         /// <param name="columnOptions">An externally-modified group of column settings</param>
         /// <param name="columnOptionsSection">A config section defining various column settings</param>
@@ -56,14 +58,14 @@ namespace Serilog
             int batchPostingLimit = MSSqlServerSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
+            ITextFormatter logEventFormatter = null,
             bool autoCreateSqlTable = false,
             ColumnOptions columnOptions = null,
             IConfigurationSection columnOptionsSection = null,
-            string schemaName = "dbo"
-            )
+            string schemaName = "dbo")
         {
-            if(loggerConfiguration == null)
-                throw new ArgumentNullException("loggerConfiguration");
+            if (loggerConfiguration == null)
+                throw new ArgumentNullException(nameof(loggerConfiguration));
 
             var defaultedPeriod = period ?? MSSqlServerSink.DefaultPeriod;
             var connectionStr = ApplyMicrosoftExtensionsConfiguration.GetConnectionString(connectionString, appConfiguration);
@@ -76,6 +78,7 @@ namespace Serilog
                     batchPostingLimit,
                     defaultedPeriod,
                     formatProvider,
+                    logEventFormatter,
                     autoCreateSqlTable,
                     colOpts,
                     schemaName
@@ -92,6 +95,7 @@ namespace Serilog
         /// <param name="appConfiguration">Additional application-level configuration. Required if connectionString is a name.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <param name="autoCreateSqlTable">Create log table with the provided name on destination sql server.</param>
         /// <param name="columnOptions">An externally-modified group of column settings</param>
         /// <param name="columnOptionsSection">A config section defining various column settings</param>
@@ -105,14 +109,14 @@ namespace Serilog
             IConfiguration appConfiguration = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null,
+            ITextFormatter logEventFormatter = null,
             bool autoCreateSqlTable = false,
             ColumnOptions columnOptions = null,
             IConfigurationSection columnOptionsSection = null,
-            string schemaName = "dbo"
-            )
+            string schemaName = "dbo")
         {
-            if(loggerAuditSinkConfiguration == null)
-                throw new ArgumentNullException("loggerAuditSinkConfiguration");
+            if (loggerAuditSinkConfiguration == null)
+                throw new ArgumentNullException(nameof(loggerAuditSinkConfiguration));
 
             var connectionStr = ApplyMicrosoftExtensionsConfiguration.GetConnectionString(connectionString, appConfiguration);
             var colOpts = ApplyMicrosoftExtensionsConfiguration.ConfigureColumnOptions(columnOptions, columnOptionsSection);
@@ -122,10 +126,10 @@ namespace Serilog
                     connectionString,
                     tableName,
                     formatProvider,
+                    logEventFormatter,
                     autoCreateSqlTable,
                     columnOptions,
-                    schemaName
-                    ),
+                    schemaName),
                 restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationMSSqlServerExtensions.cs
@@ -42,11 +42,11 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <param name="autoCreateSqlTable">Create log table with the provided name on destination sql server.</param>
         /// <param name="columnOptions">An externally-modified group of column settings</param>
         /// <param name="columnOptionsSection">A config section defining various column settings</param>
         /// <param name="schemaName">Name of the schema for the table to store the data in. The default is 'dbo'.</param>
+        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration MSSqlServer(
@@ -58,11 +58,11 @@ namespace Serilog
             int batchPostingLimit = MSSqlServerSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
-            ITextFormatter logEventFormatter = null,
             bool autoCreateSqlTable = false,
             ColumnOptions columnOptions = null,
             IConfigurationSection columnOptionsSection = null,
-            string schemaName = "dbo")
+            string schemaName = "dbo",
+            ITextFormatter logEventFormatter = null)
         {
             if (loggerConfiguration == null)
                 throw new ArgumentNullException(nameof(loggerConfiguration));
@@ -78,11 +78,10 @@ namespace Serilog
                     batchPostingLimit,
                     defaultedPeriod,
                     formatProvider,
-                    logEventFormatter,
                     autoCreateSqlTable,
                     colOpts,
-                    schemaName
-                    ),
+                    schemaName,
+                    logEventFormatter),
                 restrictedToMinimumLevel);
         }
 
@@ -95,11 +94,11 @@ namespace Serilog
         /// <param name="appConfiguration">Additional application-level configuration. Required if connectionString is a name.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <param name="autoCreateSqlTable">Create log table with the provided name on destination sql server.</param>
         /// <param name="columnOptions">An externally-modified group of column settings</param>
         /// <param name="columnOptionsSection">A config section defining various column settings</param>
         /// <param name="schemaName">Name of the schema for the table to store the data in. The default is 'dbo'.</param>
+        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration MSSqlServer(
@@ -109,11 +108,11 @@ namespace Serilog
             IConfiguration appConfiguration = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null,
-            ITextFormatter logEventFormatter = null,
             bool autoCreateSqlTable = false,
             ColumnOptions columnOptions = null,
             IConfigurationSection columnOptionsSection = null,
-            string schemaName = "dbo")
+            string schemaName = "dbo",
+            ITextFormatter logEventFormatter = null)
         {
             if (loggerAuditSinkConfiguration == null)
                 throw new ArgumentNullException(nameof(loggerAuditSinkConfiguration));
@@ -126,10 +125,10 @@ namespace Serilog
                     connectionString,
                     tableName,
                     formatProvider,
-                    logEventFormatter,
                     autoCreateSqlTable,
                     columnOptions,
-                    schemaName),
+                    schemaName,
+                    logEventFormatter),
                 restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/System.Configuration/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/System.Configuration/LoggerConfigurationMSSqlServerExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Serilog Contributors
+﻿// Copyright 2020 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ using Serilog.Configuration;
 using Serilog.Events;
 using Serilog.Sinks.MSSqlServer;
 using System.Configuration;
+using Serilog.Formatting;
 
 // System.Configuration support for .NET Framework 4.5.2 libraries and apps.
 
@@ -46,6 +47,7 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <param name="autoCreateSqlTable">Create log table with the provided name on destination sql server.</param>
         /// <param name="columnOptions"></param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
@@ -58,12 +60,13 @@ namespace Serilog
             int batchPostingLimit = MSSqlServerSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
+            ITextFormatter logEventFormatter = null,
             bool autoCreateSqlTable = false,
             ColumnOptions columnOptions = null,
-            string schemaName = "dbo"
-            )
+            string schemaName = "dbo")
         {
-            if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
+            if (loggerConfiguration == null)
+                throw new ArgumentNullException(nameof(loggerConfiguration));
 
             var defaultedPeriod = period ?? MSSqlServerSink.DefaultPeriod;
             var colOpts = columnOptions ?? new ColumnOptions();
@@ -80,10 +83,10 @@ namespace Serilog
                     batchPostingLimit,
                     defaultedPeriod,
                     formatProvider,
+                    logEventFormatter,
                     autoCreateSqlTable,
                     colOpts,
-                    schemaName
-                    ),
+                    schemaName),
                 restrictedToMinimumLevel);
         }
 
@@ -99,20 +102,24 @@ namespace Serilog
         /// <param name="schemaName">Name of the schema for the table to store the data in. The default is 'dbo'.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <param name="autoCreateSqlTable">Create log table with the provided name on destination sql server.</param>
         /// <param name="columnOptions"></param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
-        public static LoggerConfiguration MSSqlServer(this LoggerAuditSinkConfiguration loggerAuditSinkConfiguration,
-                                                      string connectionString,
-                                                      string tableName,
-                                                      LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-                                                      IFormatProvider formatProvider = null,
-                                                      bool autoCreateSqlTable = false,
-                                                      ColumnOptions columnOptions = null,
-                                                      string schemaName = "dbo")
+        public static LoggerConfiguration MSSqlServer(
+            this LoggerAuditSinkConfiguration loggerAuditSinkConfiguration,
+            string connectionString,
+            string tableName,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            IFormatProvider formatProvider = null,
+            ITextFormatter logEventFormatter = null,
+            bool autoCreateSqlTable = false,
+            ColumnOptions columnOptions = null,
+            string schemaName = "dbo")
         {
-            if (loggerAuditSinkConfiguration == null) throw new ArgumentNullException("loggerAuditSinkConfiguration");
+            if (loggerAuditSinkConfiguration == null)
+                throw new ArgumentNullException(nameof(loggerAuditSinkConfiguration));
 
             var colOpts = columnOptions ?? new ColumnOptions();
 
@@ -126,10 +133,10 @@ namespace Serilog
                     connectionString,
                     tableName,
                     formatProvider,
+                    logEventFormatter,
                     autoCreateSqlTable,
                     colOpts,
-                    schemaName
-                    ),
+                    schemaName),
                 restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/System.Configuration/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/System.Configuration/LoggerConfigurationMSSqlServerExtensions.cs
@@ -47,9 +47,9 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <param name="autoCreateSqlTable">Create log table with the provided name on destination sql server.</param>
         /// <param name="columnOptions"></param>
+        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration MSSqlServer(
@@ -60,10 +60,10 @@ namespace Serilog
             int batchPostingLimit = MSSqlServerSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
-            ITextFormatter logEventFormatter = null,
             bool autoCreateSqlTable = false,
             ColumnOptions columnOptions = null,
-            string schemaName = "dbo")
+            string schemaName = "dbo",
+            ITextFormatter logEventFormatter = null)
         {
             if (loggerConfiguration == null)
                 throw new ArgumentNullException(nameof(loggerConfiguration));
@@ -83,10 +83,10 @@ namespace Serilog
                     batchPostingLimit,
                     defaultedPeriod,
                     formatProvider,
-                    logEventFormatter,
                     autoCreateSqlTable,
                     colOpts,
-                    schemaName),
+                    schemaName,
+                    logEventFormatter),
                 restrictedToMinimumLevel);
         }
 
@@ -102,9 +102,9 @@ namespace Serilog
         /// <param name="schemaName">Name of the schema for the table to store the data in. The default is 'dbo'.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <param name="autoCreateSqlTable">Create log table with the provided name on destination sql server.</param>
         /// <param name="columnOptions"></param>
+        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration MSSqlServer(
@@ -113,10 +113,10 @@ namespace Serilog
             string tableName,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null,
-            ITextFormatter logEventFormatter = null,
             bool autoCreateSqlTable = false,
             ColumnOptions columnOptions = null,
-            string schemaName = "dbo")
+            string schemaName = "dbo",
+            ITextFormatter logEventFormatter = null)
         {
             if (loggerAuditSinkConfiguration == null)
                 throw new ArgumentNullException(nameof(loggerAuditSinkConfiguration));
@@ -133,10 +133,10 @@ namespace Serilog
                     connectionString,
                     tableName,
                     formatProvider,
-                    logEventFormatter,
                     autoCreateSqlTable,
                     colOpts,
-                    schemaName),
+                    schemaName,
+                    logEventFormatter),
                 restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/ColumnConfig.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/ColumnConfig.cs
@@ -23,7 +23,8 @@ namespace Serilog.Sinks.MSSqlServer
     public class ColumnConfig : ConfigurationElement
     {
         public ColumnConfig()
-        { }
+        {
+        }
 
         public ColumnConfig(string columnName, string dataType)
         {
@@ -43,7 +44,7 @@ namespace Serilog.Sinks.MSSqlServer
         public string DataType
         {
             get { return (string)this["DataType"]; }
-            set { this["DataType"] = value;  }
+            set { this["DataType"] = value; }
         }
 
         [ConfigurationProperty("DataLength")]

--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A Serilog sink that writes events to Microsoft SQL Server</Description>
-    <VersionPrefix>5.1.4</VersionPrefix>
+    <VersionPrefix>5.2.0</VersionPrefix>
     <Authors>Michiel van Oudheusden;Serilog Contributors</Authors>
     <TargetFrameworks>netstandard2.0;net452;netcoreapp2.0;net461</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerAuditSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerAuditSink.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Serilog Contributors 
+﻿// Copyright 2020 Serilog Contributors 
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
 using Serilog.Core;
 using Serilog.Debugging;
 using Serilog.Events;
+using Serilog.Formatting;
 using System;
 using System.Data;
 using System.Data.SqlClient;
-using System.Linq;
 using System.Text;
 
 namespace Serilog.Sinks.MSSqlServer
@@ -38,12 +38,14 @@ namespace Serilog.Sinks.MSSqlServer
         /// <param name="tableName">Name of the table to store the data in.</param>
         /// <param name="schemaName">Name of the schema for the table to store the data in. The default is 'dbo'.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <param name="autoCreateSqlTable">Create log table with the provided name on destination sql server.</param>
         /// <param name="columnOptions">Options that pertain to columns</param>
         public MSSqlServerAuditSink(
             string connectionString,
             string tableName,
             IFormatProvider formatProvider,
+            ITextFormatter logEventFormatter = null,
             bool autoCreateSqlTable = false,
             ColumnOptions columnOptions = null,
             string schemaName = "dbo"
@@ -57,7 +59,7 @@ namespace Serilog.Sinks.MSSqlServer
                     throw new NotSupportedException($"The {nameof(ColumnOptions.DisableTriggers)} option is not supported for auditing.");
             }
 
-            _traits = new MSSqlServerSinkTraits(connectionString, tableName, schemaName, columnOptions, formatProvider, autoCreateSqlTable);
+            _traits = new MSSqlServerSinkTraits(connectionString, tableName, schemaName, columnOptions, formatProvider, logEventFormatter, autoCreateSqlTable);
             
         }
 

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerAuditSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerAuditSink.cs
@@ -38,18 +38,17 @@ namespace Serilog.Sinks.MSSqlServer
         /// <param name="tableName">Name of the table to store the data in.</param>
         /// <param name="schemaName">Name of the schema for the table to store the data in. The default is 'dbo'.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <param name="autoCreateSqlTable">Create log table with the provided name on destination sql server.</param>
         /// <param name="columnOptions">Options that pertain to columns</param>
+        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         public MSSqlServerAuditSink(
             string connectionString,
             string tableName,
             IFormatProvider formatProvider,
-            ITextFormatter logEventFormatter = null,
             bool autoCreateSqlTable = false,
             ColumnOptions columnOptions = null,
-            string schemaName = "dbo"
-            )
+            string schemaName = "dbo",
+            ITextFormatter logEventFormatter = null)
         {
             columnOptions.FinalizeConfigurationForSinkConstructor();
 
@@ -59,7 +58,7 @@ namespace Serilog.Sinks.MSSqlServer
                     throw new NotSupportedException($"The {nameof(ColumnOptions.DisableTriggers)} option is not supported for auditing.");
             }
 
-            _traits = new MSSqlServerSinkTraits(connectionString, tableName, schemaName, columnOptions, formatProvider, logEventFormatter, autoCreateSqlTable);
+            _traits = new MSSqlServerSinkTraits(connectionString, tableName, schemaName, columnOptions, formatProvider, autoCreateSqlTable, logEventFormatter);
             
         }
 

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerAuditSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerAuditSink.cs
@@ -68,14 +68,14 @@ namespace Serilog.Sinks.MSSqlServer
         {
             try
             {
-                using (SqlConnection connection = new SqlConnection(_traits.connectionString))
+                using (SqlConnection connection = new SqlConnection(_traits.ConnectionString))
                 {
                     connection.Open();
                     using (SqlCommand command = connection.CreateCommand())
                     {
                         command.CommandType = CommandType.Text;
 
-                        StringBuilder fieldList = new StringBuilder($"INSERT INTO [{_traits.schemaName}].[{_traits.tableName}] (");
+                        StringBuilder fieldList = new StringBuilder($"INSERT INTO [{_traits.SchemaName}].[{_traits.TableName}] (");
                         StringBuilder parameterList = new StringBuilder(") VALUES (");
 
                         int index = 0;

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -87,23 +87,23 @@ namespace Serilog.Sinks.MSSqlServer
 
             try
             {
-                using (var cn = new SqlConnection(_traits.connectionString))
+                using (var cn = new SqlConnection(_traits.ConnectionString))
                 {
                     await cn.OpenAsync().ConfigureAwait(false);
-                    using (var copy = _traits.columnOptions.DisableTriggers
+                    using (var copy = _traits.ColumnOptions.DisableTriggers
                             ? new SqlBulkCopy(cn)
                             : new SqlBulkCopy(cn, SqlBulkCopyOptions.CheckConstraints | SqlBulkCopyOptions.FireTriggers, null)
                     )
                     {
-                        copy.DestinationTableName = string.Format("[{0}].[{1}]", _traits.schemaName, _traits.tableName);
-                        foreach (var column in _traits.eventTable.Columns)
+                        copy.DestinationTableName = string.Format("[{0}].[{1}]", _traits.SchemaName, _traits.TableName);
+                        foreach (var column in _traits.EventTable.Columns)
                         {
                             var columnName = ((DataColumn)column).ColumnName;
                             var mapping = new SqlBulkCopyColumnMapping(columnName, columnName);
                             copy.ColumnMappings.Add(mapping);
                         }
 
-                        await copy.WriteToServerAsync(_traits.eventTable).ConfigureAwait(false);
+                        await copy.WriteToServerAsync(_traits.EventTable).ConfigureAwait(false);
                     }
                 }
             }
@@ -114,7 +114,7 @@ namespace Serilog.Sinks.MSSqlServer
             finally
             {
                 // Processed the items, clear for the next run
-                _traits.eventTable.Clear();
+                _traits.EventTable.Clear();
             }
         }
 
@@ -123,17 +123,17 @@ namespace Serilog.Sinks.MSSqlServer
             // Add the new rows to the collection. 
             foreach (var logEvent in events)
             {
-                var row = _traits.eventTable.NewRow();
+                var row = _traits.EventTable.NewRow();
 
                 foreach (var field in _traits.GetColumnsAndValues(logEvent))
                 {
                     row[field.Key] = field.Value;
                 }
 
-                _traits.eventTable.Rows.Add(row);
+                _traits.EventTable.Rows.Add(row);
             }
 
-            _traits.eventTable.AcceptChanges();
+            _traits.EventTable.AcceptChanges();
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Serilog Contributors 
+﻿// Copyright 2020 Serilog Contributors 
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,13 +14,13 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Data;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 using Serilog.Debugging;
 using Serilog.Events;
+using Serilog.Formatting;
 using Serilog.Sinks.PeriodicBatching;
 
 namespace Serilog.Sinks.MSSqlServer
@@ -52,6 +52,7 @@ namespace Serilog.Sinks.MSSqlServer
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <param name="autoCreateSqlTable">Create log table with the provided name on destination sql server.</param>
         /// <param name="columnOptions">Options that pertain to columns</param>
         public MSSqlServerSink(
@@ -60,6 +61,7 @@ namespace Serilog.Sinks.MSSqlServer
             int batchPostingLimit,
             TimeSpan period,
             IFormatProvider formatProvider,
+            ITextFormatter logEventFormatter = null,
             bool autoCreateSqlTable = false,
             ColumnOptions columnOptions = null,
             string schemaName = "dbo"
@@ -67,7 +69,7 @@ namespace Serilog.Sinks.MSSqlServer
             : base(batchPostingLimit, period)
         {
             columnOptions.FinalizeConfigurationForSinkConstructor();
-            _traits = new MSSqlServerSinkTraits(connectionString, tableName, schemaName, columnOptions, formatProvider, autoCreateSqlTable);
+            _traits = new MSSqlServerSinkTraits(connectionString, tableName, schemaName, columnOptions, formatProvider, logEventFormatter, autoCreateSqlTable);
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSink.cs
@@ -52,24 +52,23 @@ namespace Serilog.Sinks.MSSqlServer
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         /// <param name="autoCreateSqlTable">Create log table with the provided name on destination sql server.</param>
         /// <param name="columnOptions">Options that pertain to columns</param>
+        /// <param name="logEventFormatter">Supplies custom formatter for the LogEvent column, or null</param>
         public MSSqlServerSink(
             string connectionString,
             string tableName,
             int batchPostingLimit,
             TimeSpan period,
             IFormatProvider formatProvider,
-            ITextFormatter logEventFormatter = null,
             bool autoCreateSqlTable = false,
             ColumnOptions columnOptions = null,
-            string schemaName = "dbo"
-            )
+            string schemaName = "dbo",
+            ITextFormatter logEventFormatter = null)
             : base(batchPostingLimit, period)
         {
             columnOptions.FinalizeConfigurationForSinkConstructor();
-            _traits = new MSSqlServerSinkTraits(connectionString, tableName, schemaName, columnOptions, formatProvider, logEventFormatter, autoCreateSqlTable);
+            _traits = new MSSqlServerSinkTraits(connectionString, tableName, schemaName, columnOptions, formatProvider, autoCreateSqlTable, logEventFormatter);
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSinkTraits.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSinkTraits.cs
@@ -23,7 +23,6 @@ using System.Data;
 using System.Linq;
 using System.Text;
 
-
 namespace Serilog.Sinks.MSSqlServer
 {
     /// <summary>Contains common functionality and properties used by both MSSqlServerSinks.</summary>
@@ -45,8 +44,8 @@ namespace Serilog.Sinks.MSSqlServer
             string schemaName,
             ColumnOptions columnOptions,
             IFormatProvider formatProvider,
-            ITextFormatter logEventFormatter,
-            bool autoCreateSqlTable)
+            bool autoCreateSqlTable,
+            ITextFormatter logEventFormatter)
         {
             if (string.IsNullOrWhiteSpace(connectionString))
                 throw new ArgumentNullException(nameof(connectionString));
@@ -151,7 +150,7 @@ namespace Serilog.Sinks.MSSqlServer
             return new KeyValuePair<string, object>(columnOptions.TimeStamp.ColumnName, dateTimeOffset.DateTime);
         }
 
-        private string LogEventToJson(LogEvent logEvent)
+        private string RenderLogEventColumn(LogEvent logEvent)
         {
             if (columnOptions.LogEvent.ExcludeAdditionalProperties)
             {

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/JsonLogEventFormatter.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/JsonLogEventFormatter.cs
@@ -1,4 +1,4 @@
-// Copyright 2018 Serilog Contributors
+// Copyright 2020 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-namespace Serilog.Sinks.MSSqlServer
+namespace Serilog.Sinks.MSSqlServer.Output
 {
     /// <summary>
     /// Custom JSON formatter to generate content for the LogEvent Standard Column.

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/JsonLogEventFormatter.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/JsonLogEventFormatter.cs
@@ -31,7 +31,7 @@ namespace Serilog.Sinks.MSSqlServer.Output
         static readonly JsonValueFormatter ValueFormatter = new JsonValueFormatter(typeTagName: null);
         private const string COMMA_DELIMITER = ",";
 
-        MSSqlServerSinkTraits traits;
+        private readonly MSSqlServerSinkTraits _traits;
  
         /// <summary>
         /// Constructor. A reference to the parent Traits object is used so that JSON
@@ -40,7 +40,7 @@ namespace Serilog.Sinks.MSSqlServer.Output
         /// </summary>
         public JsonLogEventFormatter(MSSqlServerSinkTraits parent)
         {
-            traits = parent;
+            _traits = parent;
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Serilog.Sinks.MSSqlServer.Output
 
             string precedingDelimiter = "";
 
-            if (traits.columnOptions.LogEvent.ExcludeStandardColumns == false)
+            if (_traits.ColumnOptions.LogEvent.ExcludeStandardColumns == false)
             {
                 // The XML Properties column has never included the Standard Columns, but prior
                 // to adding this sink-specific JSON formatter, the LogEvent JSON column relied
@@ -66,7 +66,7 @@ namespace Serilog.Sinks.MSSqlServer.Output
                 // whether Standard Columns are written (specifically, the subset of Standard
                 // columns that were output by the external JsonFormatter class).
 
-                var store = traits.columnOptions.Store;
+                var store = _traits.ColumnOptions.Store;
 
                 WriteIfPresent(StandardColumn.TimeStamp);
                 WriteIfPresent(StandardColumn.Level);
@@ -80,7 +80,7 @@ namespace Serilog.Sinks.MSSqlServer.Output
                     {
                         output.Write(precedingDelimiter);
                         precedingDelimiter = COMMA_DELIMITER;
-                        var colData = traits.GetStandardColumnNameAndValue(col, logEvent);
+                        var colData = _traits.GetStandardColumnNameAndValue(col, logEvent);
                         JsonValueFormatter.WriteQuotedJsonString(colData.Key, output);
                         output.Write(":");
                         string value = (col != StandardColumn.TimeStamp) ? (colData.Value ?? string.Empty).ToString() : ((DateTime)colData.Value).ToString("o");

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/XmlPropertyFormatter.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/XmlPropertyFormatter.cs
@@ -1,4 +1,4 @@
-// Copyright 2015 Serilog Contributors
+// Copyright 2020 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -20,13 +19,13 @@ using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Serilog.Events;
 
-namespace Serilog.Sinks.MSSqlServer
+namespace Serilog.Sinks.MSSqlServer.Output
 {
     /// <summary>
     ///     Converts <see cref="LogEventProperty" /> values into simple scalars,
     ///     dictionaries and lists so that they can be persisted in MSSqlServer.
     /// </summary>
-    public static class XmlPropertyFormatter
+    internal static class XmlPropertyFormatter
     {
 
         /// <summary>
@@ -185,7 +184,7 @@ namespace Serilog.Sinks.MSSqlServer
             return null;
         }
 
-        internal static string GetValidElementName(string name)
+        public static string GetValidElementName(string name)
         {
             if (string.IsNullOrWhiteSpace(name))
             {
@@ -204,7 +203,7 @@ namespace Serilog.Sinks.MSSqlServer
             return validName;
         }
 
-        static string SimplifyScalar(object value)
+        private static string SimplifyScalar(object value)
         {
             if (value == null) return null;
 

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlTableCreator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlTableCreator.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Data;
+﻿using System.Data;
 using System.Data.SqlClient;
 using System.Text;
 
-namespace Serilog.Sinks.MSSqlServer
+namespace Serilog.Sinks.MSSqlServer.Platform
 {
     internal class SqlTableCreator
     {

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlTableCreator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlTableCreator.cs
@@ -6,24 +6,24 @@ namespace Serilog.Sinks.MSSqlServer.Platform
 {
     internal class SqlTableCreator
     {
-        private readonly string connectionString;
-        private string tableName;
-        private string schemaName;
-        private DataTable dataTable;
-        private ColumnOptions columnOptions;
+        private readonly string _connectionString;
+        private readonly string _schemaName;
+        private readonly string _tableName;
+        private readonly DataTable _dataTable;
+        private readonly ColumnOptions _columnOptions;
 
         public SqlTableCreator(string connectionString, string schemaName, string tableName, DataTable dataTable, ColumnOptions columnOptions)
         {
-            this.connectionString = connectionString;
-            this.schemaName = schemaName;
-            this.tableName = tableName;
-            this.dataTable = dataTable;
-            this.columnOptions = columnOptions;
+            _connectionString = connectionString;
+            _schemaName = schemaName;
+            _tableName = tableName;
+            _dataTable = dataTable;
+            _columnOptions = columnOptions;
         }
 
         public int CreateTable()
         {
-            using (var conn = new SqlConnection(connectionString))
+            using (var conn = new SqlConnection(_connectionString))
             {
                 string sql = GetSqlFromDataTable();
                 using (SqlCommand cmd = new SqlCommand(sql, conn))
@@ -42,44 +42,44 @@ namespace Serilog.Sinks.MSSqlServer.Platform
             int indexCount = 1;
 
             // start schema check and DDL (wrap in EXEC to make a separate batch)
-            sql.AppendLine($"IF(NOT EXISTS(SELECT * FROM sys.schemas WHERE name = '{schemaName}'))");
+            sql.AppendLine($"IF(NOT EXISTS(SELECT * FROM sys.schemas WHERE name = '{_schemaName}'))");
             sql.AppendLine("BEGIN");
-            sql.AppendLine($"EXEC('CREATE SCHEMA [{schemaName}] AUTHORIZATION [dbo]')");
+            sql.AppendLine($"EXEC('CREATE SCHEMA [{_schemaName}] AUTHORIZATION [dbo]')");
             sql.AppendLine("END");
 
             // start table-creatin batch and DDL
-            sql.AppendLine($"IF NOT EXISTS (SELECT s.name, t.name FROM sys.tables t JOIN sys.schemas s ON t.schema_id = s.schema_id WHERE s.name = '{schemaName}' AND t.name = '{tableName}')");
+            sql.AppendLine($"IF NOT EXISTS (SELECT s.name, t.name FROM sys.tables t JOIN sys.schemas s ON t.schema_id = s.schema_id WHERE s.name = '{_schemaName}' AND t.name = '{_tableName}')");
             sql.AppendLine("BEGIN");
-            sql.AppendLine($"CREATE TABLE [{schemaName}].[{tableName}] ( ");
+            sql.AppendLine($"CREATE TABLE [{_schemaName}].[{_tableName}] ( ");
 
             // build column list
             int i = 1;
-            foreach (DataColumn column in dataTable.Columns)
+            foreach (DataColumn column in _dataTable.Columns)
             {
                 var common = (SqlColumn)column.ExtendedProperties["SqlColumn"];
 
                 sql.Append(GetColumnDDL(common));
-                if (dataTable.Columns.Count > i++) sql.Append(",");
+                if (_dataTable.Columns.Count > i++) sql.Append(",");
                 sql.AppendLine();
 
                 // collect non-PK indexes for separate output after the table DDL
-                if(common != null && common.NonClusteredIndex && common != columnOptions.PrimaryKey)
-                    ix.AppendLine($"CREATE NONCLUSTERED INDEX [IX{indexCount++}_{tableName}] ON [{schemaName}].[{tableName}] ([{common.ColumnName}]);");
+                if(common != null && common.NonClusteredIndex && common != _columnOptions.PrimaryKey)
+                    ix.AppendLine($"CREATE NONCLUSTERED INDEX [IX{indexCount++}_{_tableName}] ON [{_schemaName}].[{_tableName}] ([{common.ColumnName}]);");
             }
 
             // primary key constraint at the end of the table DDL
-            if (columnOptions.PrimaryKey != null)
+            if (_columnOptions.PrimaryKey != null)
             {
-                var clustering = (columnOptions.PrimaryKey.NonClusteredIndex ? "NON" : string.Empty);
-                sql.AppendLine($" CONSTRAINT [PK_{tableName}] PRIMARY KEY {clustering}CLUSTERED ([{columnOptions.PrimaryKey.ColumnName}])");
+                var clustering = (_columnOptions.PrimaryKey.NonClusteredIndex ? "NON" : string.Empty);
+                sql.AppendLine($" CONSTRAINT [PK_{_tableName}] PRIMARY KEY {clustering}CLUSTERED ([{_columnOptions.PrimaryKey.ColumnName}])");
             }
 
             // end of CREATE TABLE
             sql.AppendLine(");");
 
             // CCI is output separately after table DDL
-            if (columnOptions.ClusteredColumnstoreIndex)
-                sql.AppendLine($"CREATE CLUSTERED COLUMNSTORE INDEX [CCI_{tableName}] ON [{schemaName}].[{tableName}]");
+            if (_columnOptions.ClusteredColumnstoreIndex)
+                sql.AppendLine($"CREATE CLUSTERED COLUMNSTORE INDEX [CCI_{_tableName}] ON [{_schemaName}].[{_tableName}]");
 
             // output any extra non-clustered indexes
             sql.Append(ix);

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlDataTypes.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/SqlDataTypes.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlTypes;
 
 namespace Serilog.Sinks.MSSqlServer
 {

--- a/test/Serilog.Sinks.MSSqlServer.Tests/CustomStandardColumnNames.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/CustomStandardColumnNames.cs
@@ -10,7 +10,7 @@ using FluentAssertions;
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Collection("LogTest")]
-    public class CustomStandardColumnNames : IDisposable
+    public sealed class CustomStandardColumnNames : IDisposable
     {
         [Fact]
         public void CustomIdColumn()
@@ -21,7 +21,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             options.Id.ColumnName = customIdName;
 
             // act
-            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, true, options);
+            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, null, true, options);
 
             // assert
             using (var conn = new SqlConnection(DatabaseFixture.MasterConnectionString))
@@ -48,7 +48,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             var options = new ColumnOptions();
 
             // act
-            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, true, options);
+            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, null, true, options);
 
             // assert
             var idColumnName = "Id";
@@ -84,7 +84,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             options.Properties.ColumnName = "CustomProperties";
 
             // act
-            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, true, options);
+            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, null, true, options);
 
             // assert
             using (var conn = new SqlConnection(DatabaseFixture.MasterConnectionString))
@@ -110,7 +110,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             var standardNames = new List<string> { "Message", "MessageTemplate", "Level", "TimeStamp", "Exception", "Properties" };
 
             // act
-            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, true, options);
+            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, null, true, options);
 
             // assert
             using (var conn = new SqlConnection(DatabaseFixture.MasterConnectionString))

--- a/test/Serilog.Sinks.MSSqlServer.Tests/CustomStandardColumnNames.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/CustomStandardColumnNames.cs
@@ -21,7 +21,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             options.Id.ColumnName = customIdName;
 
             // act
-            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, null, true, options);
+            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, true, options, null);
 
             // assert
             using (var conn = new SqlConnection(DatabaseFixture.MasterConnectionString))
@@ -48,7 +48,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             var options = new ColumnOptions();
 
             // act
-            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, null, true, options);
+            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, true, options, null);
 
             // assert
             var idColumnName = "Id";
@@ -84,7 +84,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             options.Properties.ColumnName = "CustomProperties";
 
             // act
-            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, null, true, options);
+            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, true, options, null);
 
             // assert
             using (var conn = new SqlConnection(DatabaseFixture.MasterConnectionString))
@@ -110,7 +110,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             var standardNames = new List<string> { "Message", "MessageTemplate", "Level", "TimeStamp", "Exception", "Properties" };
 
             // act
-            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, null, true, options);
+            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, true, options, null);
 
             // assert
             using (var conn = new SqlConnection(DatabaseFixture.MasterConnectionString))

--- a/test/Serilog.Sinks.MSSqlServer.Tests/CustomStandardColumnNames.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/CustomStandardColumnNames.cs
@@ -21,7 +21,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             options.Id.ColumnName = customIdName;
 
             // act
-            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, true, options, null);
+            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, true, options, "dbo", null);
 
             // assert
             using (var conn = new SqlConnection(DatabaseFixture.MasterConnectionString))
@@ -48,7 +48,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             var options = new ColumnOptions();
 
             // act
-            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, true, options, null);
+            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, true, options, "dbo", null);
 
             // assert
             var idColumnName = "Id";
@@ -84,7 +84,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             options.Properties.ColumnName = "CustomProperties";
 
             // act
-            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, true, options, null);
+            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, true, options, "dbo", null);
 
             // assert
             using (var conn = new SqlConnection(DatabaseFixture.MasterConnectionString))
@@ -110,7 +110,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             var standardNames = new List<string> { "Message", "MessageTemplate", "Level", "TimeStamp", "Exception", "Properties" };
 
             // act
-            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, true, options, null);
+            var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, true, options,  "dbo", null);
 
             // assert
             using (var conn = new SqlConnection(DatabaseFixture.MasterConnectionString))

--- a/test/Serilog.Sinks.MSSqlServer.Tests/DatabaseFixture.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/DatabaseFixture.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
-    public class DatabaseFixture : IDisposable
+    public sealed class DatabaseFixture : IDisposable
     {
         public static string Database => "LogTest";
         public static string LogTableName => "LogEvents";

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Serilog.Sinks.MSSqlServer.Tests.csproj
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Serilog.Sinks.MSSqlServer.Tests.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Dapper.StrongName" Version="1.50.5" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
   </ItemGroup>
 

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/TestMSSqlServerSinkTraits.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/TestMSSqlServerSinkTraits.cs
@@ -101,8 +101,8 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Sinks.MSSqlServer
 
         private void SetupTest(Serilog.Sinks.MSSqlServer.ColumnOptions options, DateTimeOffset testDateTimeOffset)
         {
-            this.traits = new MSSqlServerSinkTraits("connectionString", "tableName", "schemaName",
-                options, CultureInfo.InvariantCulture, false);
+            this.traits = new MSSqlServerSinkTraits("connectionString", "tableName", "schemaName", 
+                options, CultureInfo.InvariantCulture, false, null);
             this.logEvent = new LogEvent(testDateTimeOffset, LogEventLevel.Information, null,
                 new MessageTemplate(new List<MessageTemplateToken>()), new List<LogEventProperty>());
         }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/TestMSSqlServerSinkTraits.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/TestMSSqlServerSinkTraits.cs
@@ -1,9 +1,12 @@
-﻿using Serilog.Events;
+﻿using Moq;
+using Serilog.Events;
+using Serilog.Formatting;
 using Serilog.Parsing;
 using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using Xunit;
 
@@ -99,10 +102,52 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Sinks.MSSqlServer
             Assert.Equal(new TimeSpan(0), timeStampColumnOffset.Offset);
         }
 
-        private void SetupTest(Serilog.Sinks.MSSqlServer.ColumnOptions options, DateTimeOffset testDateTimeOffset)
+        [Fact]
+        public void GetColumnsAndValuesWhenCalledWithCustomFormatterRendersLogEventPropertyUsingCustomFormatter()
+        {
+            // arrange
+            const string testLogEventContent = "Content of LogEvent";
+            var options = new Serilog.Sinks.MSSqlServer.ColumnOptions();
+            options.Store.Add(StandardColumn.LogEvent);
+            var logEventFormatterMock = new Mock<ITextFormatter>();
+            logEventFormatterMock.Setup(f => f.Format(It.IsAny<LogEvent>(), It.IsAny<TextWriter>()))
+                .Callback<LogEvent, TextWriter>((e, w) => w.Write(testLogEventContent));
+            SetupTest(options, DateTimeOffset.UtcNow, logEventFormatterMock.Object);
+
+            // act
+            var columns = traits.GetColumnsAndValues(logEvent);
+
+            // assert
+            var logEventColumn = columns.Single(c => c.Key == options.LogEvent.ColumnName);
+            Assert.Equal(testLogEventContent, logEventColumn.Value);
+        }
+
+        [Fact]
+        public void GetColumnsAndValuesWhenCalledWithoutFormatterRendersLogEventPropertyUsingInternalJsonFormatter()
+        {
+            // arrange
+            const string expectedLogEventContent =
+                "{\"TimeStamp\":\"2020-01-01T09:00:00.0000000\",\"Level\":\"Information\",\"Message\":\"\",\"MessageTemplate\":\"\"}";
+            var options = new Serilog.Sinks.MSSqlServer.ColumnOptions();
+            options.Store.Add(StandardColumn.LogEvent);
+            var testDateTimeOffset = new DateTimeOffset(2020, 1, 1, 9, 0, 0, TimeSpan.Zero);
+            SetupTest(options, testDateTimeOffset, null);
+
+            // act
+            var columns = traits.GetColumnsAndValues(logEvent);
+
+            // assert
+            var logEventColumn = columns.Single(c => c.Key == options.LogEvent.ColumnName);
+            Assert.Equal(expectedLogEventContent, logEventColumn.Value);
+        }
+
+        private void SetupTest(
+            Serilog.Sinks.MSSqlServer.ColumnOptions options,
+            DateTimeOffset testDateTimeOffset,
+            ITextFormatter logEventFormatter = null)
         {
             this.traits = new MSSqlServerSinkTraits("connectionString", "tableName", "schemaName", 
-                options, CultureInfo.InvariantCulture, false, null);
+                options, CultureInfo.InvariantCulture, false, logEventFormatter);
             this.logEvent = new LogEvent(testDateTimeOffset, LogEventLevel.Information, null,
                 new MessageTemplate(new List<MessageTemplateToken>()), new List<LogEventProperty>());
         }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/TestMiscFeatures.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/TestMiscFeatures.cs
@@ -10,7 +10,7 @@ using Xunit;
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Collection("LogTest")]
-    public class TestMiscFeatures : IDisposable
+    public sealed class TestMiscFeatures : IDisposable
     {
         [Fact]
         public void LogEventExcludeAdditionalProperties()

--- a/test/Serilog.Sinks.MSSqlServer.Tests/TestSqlTypes.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/TestSqlTypes.cs
@@ -2,16 +2,12 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Data;
-using System.Data.SqlClient;
-using System.Linq;
-using Dapper;
-using FluentAssertions;
 using Xunit;
 
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Collection("LogTest")]
-    public class TestSqlTypes : IDisposable
+    public sealed class TestSqlTypes : IDisposable
     {
         // Since the point of these tests are to validate we can write to
         // specific underlying SQL Server column data types, we use audit


### PR DESCRIPTION
* Implemented issue #232 Allow custom ITextFormatter for rendering LogEvent column.
* Added a small sample to demonstrate using a custom LogEvent column formatter.
* Cleanups and small refactorings where possible. 