### PR TITLE
Refactoring, cleanup and tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,20 @@
-5.2
+5.2.0
+ * Enhancement #232: Allow to override formatter for rendering LogEvent column.
+ * Fixed #187 (again - still an exception when using logevent column with TimeStamp column type DateTimeOffset).
+ * Added sample programs
+
+5.1.4
+ * Fixed #187 Support datetimeoffset as a column type for default column TimeStamp.
+ * Fixed #229 Slight issue with documentation.
+
+5.1.3
+ * Support binary data type, support specify data length in column config, support specify allow null column
+ * Also build on unit-test commits
+ * Added issue templase
+ * Hybrid config implementation
+ * Bugfixes
+
+5.1.2
  * Support for Audit sink added (#118/#110).
 
 4.0.0

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/IConnectionStringProvider.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/IConnectionStringProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace Serilog.Sinks.MSSqlServer.Configuration
+{
+    internal interface IConnectionStringProvider
+    {
+        string GetConnectionString(string nameOrConnectionString);
+    }
+}

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/Microsoft.Extensions.Configuration/ApplyMicrosoftExtensionsConfiguration.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/Microsoft.Extensions.Configuration/ApplyMicrosoftExtensionsConfiguration.cs
@@ -1,9 +1,5 @@
 ﻿using Microsoft.Extensions.Configuration;
-using Serilog.Debugging;
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
+using Serilog.Sinks.MSSqlServer.Configuration;
 
 namespace Serilog.Sinks.MSSqlServer
 {
@@ -12,6 +8,10 @@ namespace Serilog.Sinks.MSSqlServer
     /// </summary>
     internal static class ApplyMicrosoftExtensionsConfiguration
     {
+        internal static IMicrosoftExtensionsConnectionStringProvider ConnectionStringProvider { get; set; } = new MicrosoftExtensionsConnectionStringProvider();
+
+        internal static IMicrosoftExtensionsColumnOptionsProvider ColumnOptionsProvider { get; set; } = new MicrosoftExtensionsColumnOptionsProvider();
+
         /// <summary>
         /// Examine if supplied connection string is a reference to an item in the "ConnectionStrings" section of web.config
         /// If it is, return the ConnectionStrings item, if not, return string as supplied.
@@ -19,18 +19,8 @@ namespace Serilog.Sinks.MSSqlServer
         /// <param name="nameOrConnectionString">The name of the ConnectionStrings key or raw connection string.</param>
         /// <param name="appConfiguration">Additional application-level configuration.</param>
         /// <remarks>Pulled from review of Entity Framework 6 methodology for doing the same</remarks>
-        internal static string GetConnectionString(string nameOrConnectionString, IConfiguration appConfiguration)
-        {
-            // If there is an `=`, we assume this is a raw connection string not a named value
-            // If there are no `=`, attempt to pull the named value from config
-            if (nameOrConnectionString.IndexOf('=') > -1) return nameOrConnectionString;
-            string cs = appConfiguration?.GetConnectionString(nameOrConnectionString);
-            if (string.IsNullOrEmpty(cs))
-            {
-                SelfLog.WriteLine("MSSqlServer sink configured value {0} is not found in ConnectionStrings settings and does not appear to be a raw connection string.", nameOrConnectionString);
-            }
-            return cs;
-        }
+        internal static string GetConnectionString(string nameOrConnectionString, IConfiguration appConfiguration) =>
+            ConnectionStringProvider.GetConnectionString(nameOrConnectionString, appConfiguration);
 
         /// <summary>
         /// Create or add to the ColumnOptions object and apply any configuration changes to it.
@@ -38,182 +28,7 @@ namespace Serilog.Sinks.MSSqlServer
         /// <param name="columnOptions">An optional externally-created ColumnOptions object to be updated with additional configuration values.</param>
         /// <param name="config">A configuration section typically named "columnOptionsSection" (see docs).</param>
         /// <returns></returns>
-        internal static ColumnOptions ConfigureColumnOptions(ColumnOptions columnOptions, IConfigurationSection config)
-        {
-            // Do not use configuration binding (ie GetSection.Get<ColumnOptions>). That will create a new
-            // ColumnOptions object which would overwrite settings if the caller passed in a ColumnOptions
-            // object via the extension method's columnOptions parameter.
-
-            var opts = columnOptions ?? new ColumnOptions();
-            if (config == null || !config.GetChildren().Any()) return opts;
-
-            AddRemoveStandardColumns();
-            AddAdditionalColumns();
-            ReadStandardColumns();
-            ReadMiscColumnOptions();
-
-            return opts;
-
-            void AddRemoveStandardColumns()
-            {
-                // add standard columns
-                var addStd = config.GetSection("addStandardColumns");
-                if (addStd.GetChildren().Any())
-                {
-                    foreach (var col in addStd.GetChildren().ToList())
-                    {
-                        if (Enum.TryParse(col.Value, ignoreCase: true, result: out StandardColumn stdcol)
-                            && !opts.Store.Contains(stdcol))
-                            opts.Store.Add(stdcol);
-                    }
-                }
-
-                // remove standard columns
-                var removeStd = config.GetSection("removeStandardColumns");
-                if (removeStd.GetChildren().Any())
-                {
-                    foreach (var col in removeStd.GetChildren().ToList())
-                    {
-                        if (Enum.TryParse(col.Value, ignoreCase: true, result: out StandardColumn stdcol)
-                            && opts.Store.Contains(stdcol))
-                            opts.Store.Remove(stdcol);
-                    }
-                }
-            }
-
-            void AddAdditionalColumns()
-            {
-                var newcols =
-                    config.GetSection("additionalColumns").Get<List<SqlColumn>>()
-                    ?? config.GetSection("customColumns").Get<List<SqlColumn>>(); // backwards-compatibility
-
-                if (newcols != null)
-                {
-                    foreach (var c in newcols)
-                    {
-                        if (!string.IsNullOrWhiteSpace(c.ColumnName))
-                        {
-                            if (opts.AdditionalColumns == null)
-                                opts.AdditionalColumns = new Collection<SqlColumn>();
-
-                            opts.AdditionalColumns.Add(c);
-                        }
-                    }
-                }
-            }
-
-            void ReadStandardColumns()
-            {
-                var section = config.GetSection("id");
-                if (section != null)
-                {
-                    SetCommonColumnOptions(opts.Id);
-#pragma warning disable 618 // deprecated: BigInt property
-                    SetProperty.IfNotNull<bool>(section["bigInt"], (val) => opts.Id.BigInt = val);
-#pragma warning restore 618
-                }
-
-                section = config.GetSection("level");
-                if (section != null)
-                {
-                    SetCommonColumnOptions(opts.Level);
-                    SetProperty.IfNotNull<bool>(section["storeAsEnum"], (val) => opts.Level.StoreAsEnum = val);
-                }
-
-                section = config.GetSection("properties");
-                if (section != null)
-                {
-                    SetCommonColumnOptions(opts.Properties);
-                    SetProperty.IfNotNull<bool>(section["excludeAdditionalProperties"], (val) => opts.Properties.ExcludeAdditionalProperties = val);
-                    SetProperty.IfNotNull<string>(section["dictionaryElementName"], (val) => opts.Properties.DictionaryElementName = val);
-                    SetProperty.IfNotNull<string>(section["itemElementName"], (val) => opts.Properties.ItemElementName = val);
-                    SetProperty.IfNotNull<bool>(section["omitDictionaryContainerElement"], (val) => opts.Properties.OmitDictionaryContainerElement = val);
-                    SetProperty.IfNotNull<bool>(section["omitSequenceContainerElement"], (val) => opts.Properties.OmitSequenceContainerElement = val);
-                    SetProperty.IfNotNull<bool>(section["omitStructureContainerElement"], (val) => opts.Properties.OmitStructureContainerElement = val);
-                    SetProperty.IfNotNull<bool>(section["omitElementIfEmpty"], (val) => opts.Properties.OmitElementIfEmpty = val);
-                    SetProperty.IfNotNull<string>(section["propertyElementName"], (val) => opts.Properties.PropertyElementName = val);
-                    SetProperty.IfNotNull<string>(section["rootElementName"], (val) => opts.Properties.RootElementName = val);
-                    SetProperty.IfNotNull<string>(section["sequenceElementName"], (val) => opts.Properties.SequenceElementName = val);
-                    SetProperty.IfNotNull<string>(section["structureElementName"], (val) => opts.Properties.StructureElementName = val);
-                    SetProperty.IfNotNull<bool>(section["usePropertyKeyAsElementName"], (val) => opts.Properties.UsePropertyKeyAsElementName = val);
-                    // TODO PropertiesFilter would need a compiled Predicate<string> (high Roslyn overhead, see Serilog Config repo #106)
-                }
-
-                section = config.GetSection("timeStamp");
-                if (section != null)
-                {
-                    SetCommonColumnOptions(opts.TimeStamp);
-                    SetProperty.IfNotNull<bool>(section["convertToUtc"], (val) => opts.TimeStamp.ConvertToUtc = val);
-                }
-
-                section = config.GetSection("logEvent");
-                if (section != null)
-                {
-                    SetCommonColumnOptions(opts.LogEvent);
-                    SetProperty.IfNotNull<bool>(section["excludeAdditionalProperties"], (val) => opts.LogEvent.ExcludeAdditionalProperties = val);
-                    SetProperty.IfNotNull<bool>(section["ExcludeStandardColumns"], (val) => opts.LogEvent.ExcludeStandardColumns = val);
-                }
-
-                section = config.GetSection("message");
-                if (section != null)
-                    SetCommonColumnOptions(opts.Message);
-
-                section = config.GetSection("exception");
-                if (section != null)
-                    SetCommonColumnOptions(opts.Exception);
-
-                section = config.GetSection("messageTemplate");
-                if (section != null)
-                    SetCommonColumnOptions(opts.MessageTemplate);
-
-                // Standard Columns are subclasses of the SqlColumn class
-                void SetCommonColumnOptions(SqlColumn target)
-                {
-                    SetProperty.IfNotNullOrEmpty<string>(section["columnName"], (val) => target.ColumnName = val);
-                    SetProperty.IfNotNull<string>(section["dataType"], (val) => target.SetDataTypeFromConfigString(val));
-                    SetProperty.IfNotNull<bool>(section["allowNull"], (val) => target.AllowNull = val);
-                    SetProperty.IfNotNull<int>(section["dataLength"], (val) => target.DataLength = val);
-                    SetProperty.IfNotNull<bool>(section["nonClusteredIndex"], (val) => target.NonClusteredIndex = val);
-                }
-            }
-
-            void ReadMiscColumnOptions()
-            {
-                SetProperty.IfNotNull<bool>(config["disableTriggers"], (val) => opts.DisableTriggers = val);
-                SetProperty.IfNotNull<bool>(config["clusteredColumnstoreIndex"], (val) => opts.ClusteredColumnstoreIndex = val);
-
-                string pkName = config["primaryKeyColumnName"];
-                if (!string.IsNullOrEmpty(pkName))
-                {
-                    if (opts.ClusteredColumnstoreIndex)
-                        throw new ArgumentException("SQL Clustered Columnstore Indexes and primary key constraints are mutually exclusive.");
-
-                    foreach (var standardCol in opts.Store)
-                    {
-                        var stdColOpts = opts.GetStandardColumnOptions(standardCol);
-                        if (pkName.Equals(stdColOpts.ColumnName, StringComparison.InvariantCultureIgnoreCase))
-                        {
-                            opts.PrimaryKey = stdColOpts;
-                            break;
-                        }
-                    }
-
-                    if (opts.PrimaryKey == null && opts.AdditionalColumns != null)
-                    {
-                        foreach (var col in opts.AdditionalColumns)
-                        {
-                            if (pkName.Equals(col.ColumnName, StringComparison.InvariantCultureIgnoreCase))
-                            {
-                                opts.PrimaryKey = col;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (opts.PrimaryKey == null)
-                        throw new ArgumentException($"Could not match the configured primary key column name \"{pkName}\" with a data column in the table.");
-                }
-            }
-        }
+        internal static ColumnOptions ConfigureColumnOptions(ColumnOptions columnOptions, IConfigurationSection config) =>
+            ColumnOptionsProvider.ConfigureColumnOptions(columnOptions, config);
     }
 }

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/Microsoft.Extensions.Configuration/IMicrosoftExtensionsColumnOptionsProvider.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/Microsoft.Extensions.Configuration/IMicrosoftExtensionsColumnOptionsProvider.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace Serilog.Sinks.MSSqlServer.Configuration
+{
+    internal interface IMicrosoftExtensionsColumnOptionsProvider
+    {
+        ColumnOptions ConfigureColumnOptions(ColumnOptions columnOptions, IConfigurationSection config);
+    }
+}

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/Microsoft.Extensions.Configuration/IMicrosoftExtensionsConnectionStringProvider.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/Microsoft.Extensions.Configuration/IMicrosoftExtensionsConnectionStringProvider.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace Serilog.Sinks.MSSqlServer.Configuration
+{
+    internal interface IMicrosoftExtensionsConnectionStringProvider
+    {
+        string GetConnectionString(string nameOrConnectionString, IConfiguration appConfiguration);
+    }
+}

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/Microsoft.Extensions.Configuration/MicrosoftExtensionsColumnOptionsProvider.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/Microsoft.Extensions.Configuration/MicrosoftExtensionsColumnOptionsProvider.cs
@@ -1,0 +1,189 @@
+﻿using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Serilog.Sinks.MSSqlServer.Configuration
+{
+    internal class MicrosoftExtensionsColumnOptionsProvider : IMicrosoftExtensionsColumnOptionsProvider
+    {
+        public ColumnOptions ConfigureColumnOptions(ColumnOptions columnOptions, IConfigurationSection config)
+        {
+            // Do not use configuration binding (ie GetSection.Get<ColumnOptions>). That will create a new
+            // ColumnOptions object which would overwrite settings if the caller passed in a ColumnOptions
+            // object via the extension method's columnOptions parameter.
+
+            columnOptions = columnOptions ?? new ColumnOptions();
+            if (config == null || !config.GetChildren().Any()) return columnOptions;
+
+            AddRemoveStandardColumns(config, columnOptions);
+            AddAdditionalColumns(config, columnOptions);
+            ReadStandardColumns(config, columnOptions);
+            ReadMiscColumnOptions(config, columnOptions);
+
+            return columnOptions;
+        }
+
+        private void AddRemoveStandardColumns(IConfigurationSection config, ColumnOptions columnOptions)
+        {
+            // add standard columns
+            var addStd = config.GetSection("addStandardColumns");
+            if (addStd.GetChildren().Any())
+            {
+                foreach (var col in addStd.GetChildren().ToList())
+                {
+                    if (Enum.TryParse(col.Value, ignoreCase: true, result: out StandardColumn stdcol)
+                        && !columnOptions.Store.Contains(stdcol))
+                        columnOptions.Store.Add(stdcol);
+                }
+            }
+
+            // remove standard columns
+            var removeStd = config.GetSection("removeStandardColumns");
+            if (removeStd.GetChildren().Any())
+            {
+                foreach (var col in removeStd.GetChildren().ToList())
+                {
+                    if (Enum.TryParse(col.Value, ignoreCase: true, result: out StandardColumn stdcol)
+                        && columnOptions.Store.Contains(stdcol))
+                        columnOptions.Store.Remove(stdcol);
+                }
+            }
+        }
+
+        private void AddAdditionalColumns(IConfigurationSection config, ColumnOptions columnOptions)
+        {
+            var newcols =
+                config.GetSection("additionalColumns").Get<List<SqlColumn>>()
+                ?? config.GetSection("customColumns").Get<List<SqlColumn>>(); // backwards-compatibility
+
+            if (newcols != null)
+            {
+                foreach (var c in newcols)
+                {
+                    if (!string.IsNullOrWhiteSpace(c.ColumnName))
+                    {
+                        if (columnOptions.AdditionalColumns == null)
+                            columnOptions.AdditionalColumns = new Collection<SqlColumn>();
+
+                        columnOptions.AdditionalColumns.Add(c);
+                    }
+                }
+            }
+        }
+
+        private void ReadStandardColumns(IConfigurationSection config, ColumnOptions columnOptions)
+        {
+            var section = config.GetSection("id");
+            if (section != null)
+            {
+                SetCommonColumnOptions(section, columnOptions.Id);
+#pragma warning disable 618 // deprecated: BigInt property
+                SetProperty.IfNotNull<bool>(section["bigInt"], (val) => columnOptions.Id.BigInt = val);
+#pragma warning restore 618
+            }
+
+            section = config.GetSection("level");
+            if (section != null)
+            {
+                SetCommonColumnOptions(section, columnOptions.Level);
+                SetProperty.IfNotNull<bool>(section["storeAsEnum"], (val) => columnOptions.Level.StoreAsEnum = val);
+            }
+
+            section = config.GetSection("properties");
+            if (section != null)
+            {
+                SetCommonColumnOptions(section, columnOptions.Properties);
+                SetProperty.IfNotNull<bool>(section["excludeAdditionalProperties"], (val) => columnOptions.Properties.ExcludeAdditionalProperties = val);
+                SetProperty.IfNotNull<string>(section["dictionaryElementName"], (val) => columnOptions.Properties.DictionaryElementName = val);
+                SetProperty.IfNotNull<string>(section["itemElementName"], (val) => columnOptions.Properties.ItemElementName = val);
+                SetProperty.IfNotNull<bool>(section["omitDictionaryContainerElement"], (val) => columnOptions.Properties.OmitDictionaryContainerElement = val);
+                SetProperty.IfNotNull<bool>(section["omitSequenceContainerElement"], (val) => columnOptions.Properties.OmitSequenceContainerElement = val);
+                SetProperty.IfNotNull<bool>(section["omitStructureContainerElement"], (val) => columnOptions.Properties.OmitStructureContainerElement = val);
+                SetProperty.IfNotNull<bool>(section["omitElementIfEmpty"], (val) => columnOptions.Properties.OmitElementIfEmpty = val);
+                SetProperty.IfNotNull<string>(section["propertyElementName"], (val) => columnOptions.Properties.PropertyElementName = val);
+                SetProperty.IfNotNull<string>(section["rootElementName"], (val) => columnOptions.Properties.RootElementName = val);
+                SetProperty.IfNotNull<string>(section["sequenceElementName"], (val) => columnOptions.Properties.SequenceElementName = val);
+                SetProperty.IfNotNull<string>(section["structureElementName"], (val) => columnOptions.Properties.StructureElementName = val);
+                SetProperty.IfNotNull<bool>(section["usePropertyKeyAsElementName"], (val) => columnOptions.Properties.UsePropertyKeyAsElementName = val);
+                // TODO PropertiesFilter would need a compiled Predicate<string> (high Roslyn overhead, see Serilog Config repo #106)
+            }
+
+            section = config.GetSection("timeStamp");
+            if (section != null)
+            {
+                SetCommonColumnOptions(section, columnOptions.TimeStamp);
+                SetProperty.IfNotNull<bool>(section["convertToUtc"], (val) => columnOptions.TimeStamp.ConvertToUtc = val);
+            }
+
+            section = config.GetSection("logEvent");
+            if (section != null)
+            {
+                SetCommonColumnOptions(section, columnOptions.LogEvent);
+                SetProperty.IfNotNull<bool>(section["excludeAdditionalProperties"], (val) => columnOptions.LogEvent.ExcludeAdditionalProperties = val);
+                SetProperty.IfNotNull<bool>(section["ExcludeStandardColumns"], (val) => columnOptions.LogEvent.ExcludeStandardColumns = val);
+            }
+
+            section = config.GetSection("message");
+            if (section != null)
+                SetCommonColumnOptions(section, columnOptions.Message);
+
+            section = config.GetSection("exception");
+            if (section != null)
+                SetCommonColumnOptions(section, columnOptions.Exception);
+
+            section = config.GetSection("messageTemplate");
+            if (section != null)
+                SetCommonColumnOptions(section, columnOptions.MessageTemplate);
+        }
+
+        private void SetCommonColumnOptions(IConfigurationSection section, SqlColumn target)
+        {
+            // Standard Columns are subclasses of the SqlColumn class
+            SetProperty.IfNotNullOrEmpty<string>(section["columnName"], (val) => target.ColumnName = val);
+            SetProperty.IfNotNull<string>(section["dataType"], (val) => target.SetDataTypeFromConfigString(val));
+            SetProperty.IfNotNull<bool>(section["allowNull"], (val) => target.AllowNull = val);
+            SetProperty.IfNotNull<int>(section["dataLength"], (val) => target.DataLength = val);
+            SetProperty.IfNotNull<bool>(section["nonClusteredIndex"], (val) => target.NonClusteredIndex = val);
+        }
+
+        private void ReadMiscColumnOptions(IConfigurationSection config, ColumnOptions columnOptions)
+        {
+            SetProperty.IfNotNull<bool>(config["disableTriggers"], (val) => columnOptions.DisableTriggers = val);
+            SetProperty.IfNotNull<bool>(config["clusteredColumnstoreIndex"], (val) => columnOptions.ClusteredColumnstoreIndex = val);
+
+            string pkName = config["primaryKeyColumnName"];
+            if (!string.IsNullOrEmpty(pkName))
+            {
+                if (columnOptions.ClusteredColumnstoreIndex)
+                    throw new ArgumentException("SQL Clustered Columnstore Indexes and primary key constraints are mutually exclusive.");
+
+                foreach (var standardCol in columnOptions.Store)
+                {
+                    var stdColcolumnOptions = columnOptions.GetStandardColumnOptions(standardCol);
+                    if (pkName.Equals(stdColcolumnOptions.ColumnName, StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        columnOptions.PrimaryKey = stdColcolumnOptions;
+                        break;
+                    }
+                }
+
+                if (columnOptions.PrimaryKey == null && columnOptions.AdditionalColumns != null)
+                {
+                    foreach (var col in columnOptions.AdditionalColumns)
+                    {
+                        if (pkName.Equals(col.ColumnName, StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            columnOptions.PrimaryKey = col;
+                            break;
+                        }
+                    }
+                }
+
+                if (columnOptions.PrimaryKey == null)
+                    throw new ArgumentException($"Could not match the configured primary key column name \"{pkName}\" with a data column in the table.");
+            }
+        }
+    }
+}

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/Microsoft.Extensions.Configuration/MicrosoftExtensionsConnectionStringProvider.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/Microsoft.Extensions.Configuration/MicrosoftExtensionsConnectionStringProvider.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.Configuration;
+using Serilog.Debugging;
+
+namespace Serilog.Sinks.MSSqlServer.Configuration
+{
+    internal class MicrosoftExtensionsConnectionStringProvider : IMicrosoftExtensionsConnectionStringProvider
+    {
+        public string GetConnectionString(string nameOrConnectionString, IConfiguration appConfiguration)
+        {
+            // If there is an `=`, we assume this is a raw connection string not a named value
+            // If there are no `=`, attempt to pull the named value from config
+            if (nameOrConnectionString.IndexOf('=') > -1) return nameOrConnectionString;
+            string cs = appConfiguration?.GetConnectionString(nameOrConnectionString);
+            if (string.IsNullOrEmpty(cs))
+            {
+                SelfLog.WriteLine("MSSqlServer sink configured value {0} is not found in ConnectionStrings settings and does not appear to be a raw connection string.",
+                    nameOrConnectionString);
+            }
+            return cs;
+        }
+    }
+}

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/ApplySystemConfiguration.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/ApplySystemConfiguration.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.ObjectModel;
-using Serilog.Configuration;
-using System.Configuration;
-using Serilog.Debugging;
+﻿using Serilog.Configuration;
+using Serilog.Sinks.MSSqlServer.Configuration;
 
 namespace Serilog.Sinks.MSSqlServer
 {
@@ -11,170 +8,23 @@ namespace Serilog.Sinks.MSSqlServer
     /// </summary>
     internal static class ApplySystemConfiguration
     {
+        internal static IConnectionStringProvider ConnectionStringProvider { get; set; } = new SystemConfigurationConnectionStringProvider();
+
+        internal static ISystemConfigurationColumnOptionsProvider ColumnOptionsProvider { get; set; } = new SystemConfigurationColumnOptionsProvider();
+
         /// <summary>
         /// Examine if supplied connection string is a reference to an item in the "ConnectionStrings" section of web.config
         /// If it is, return the ConnectionStrings item, if not, return string as supplied.
         /// </summary>
         /// <param name="nameOrConnectionString">The name of the ConnectionStrings key or raw connection string.</param>
         /// <remarks>Pulled from review of Entity Framework 6 methodology for doing the same</remarks>
-        internal static string GetConnectionString(string nameOrConnectionString)
-        {
-
-            // If there is an `=`, we assume this is a raw connection string not a named value
-            // If there are no `=`, attempt to pull the named value from config
-            if (nameOrConnectionString.IndexOf('=') < 0)
-            {
-                var cs = ConfigurationManager.ConnectionStrings[nameOrConnectionString];
-                if (cs != null)
-                {
-                    return cs.ConnectionString;
-                }
-                else
-                {
-                    SelfLog.WriteLine("MSSqlServer sink configured value {0} is not found in ConnectionStrings settings and does not appear to be a raw connection string.", nameOrConnectionString);
-                }
-            }
-
-            return nameOrConnectionString;
-        }
+        internal static string GetConnectionString(string nameOrConnectionString) =>
+            ConnectionStringProvider.GetConnectionString(nameOrConnectionString);
 
         /// <summary>
         /// Populate ColumnOptions properties and collections from app config
         /// </summary>
-        internal static ColumnOptions ConfigureColumnOptions(MSSqlServerConfigurationSection config, ColumnOptions columnOptions)
-        {
-            var opts = columnOptions ?? new ColumnOptions();
-
-            AddRmoveStandardColumns();
-            AddAdditionalColumns();
-            ReadStandardColumns();
-            ReadMiscColumnOptions();
-
-            return opts;
-
-            void AddRmoveStandardColumns()
-            {
-                // add standard columns
-                if (config.AddStandardColumns.Count > 0)
-                {
-                    foreach (StandardColumnConfig col in config.AddStandardColumns)
-                    {
-                        if (Enum.TryParse(col.Name, ignoreCase: true, result: out StandardColumn stdcol)
-                            && !opts.Store.Contains(stdcol))
-                            opts.Store.Add(stdcol);
-                    }
-                }
-
-                // remove standard columns
-                if (config.RemoveStandardColumns.Count > 0)
-                {
-                    foreach (StandardColumnConfig col in config.RemoveStandardColumns)
-                    {
-                        if (Enum.TryParse(col.Name, ignoreCase: true, result: out StandardColumn stdcol)
-                            && opts.Store.Contains(stdcol))
-                            opts.Store.Remove(stdcol);
-                    }
-                }
-            }
-
-            void AddAdditionalColumns()
-            {
-                if (config.Columns.Count > 0)
-                {
-                    foreach (ColumnConfig c in config.Columns)
-                    {
-                        if (!string.IsNullOrWhiteSpace(c.ColumnName))
-                        {
-                            if (opts.AdditionalColumns == null)
-                                opts.AdditionalColumns = new Collection<SqlColumn>();
-
-                            opts.AdditionalColumns.Add(c.AsSqlColumn());
-                        }
-                    }
-
-                }
-            }
-
-            void ReadStandardColumns()
-            {
-                SetCommonColumnOptions(config.Exception, opts.Exception);
-                SetCommonColumnOptions(config.Id, opts.Id);
-                SetCommonColumnOptions(config.Level, opts.Level);
-                SetCommonColumnOptions(config.LogEvent, opts.LogEvent);
-                SetCommonColumnOptions(config.Message, opts.Message);
-                SetCommonColumnOptions(config.MessageTemplate, opts.MessageTemplate);
-                SetCommonColumnOptions(config.PropertiesColumn, opts.Properties);
-                SetCommonColumnOptions(config.TimeStamp, opts.TimeStamp);
-
-                SetProperty.IfProvided<bool>(config.Level, "StoreAsEnum", (val) => opts.Level.StoreAsEnum = val);
-
-                SetProperty.IfProvided<bool>(config.LogEvent, "ExcludeStandardColumns", (val) => opts.LogEvent.ExcludeStandardColumns = val);
-                SetProperty.IfProvided<bool>(config.LogEvent, "ExcludeAdditionalProperties", (val) => opts.LogEvent.ExcludeAdditionalProperties = val);
-
-                SetProperty.IfProvided<bool>(config.PropertiesColumn, "ExcludeAdditionalProperties", (val) => opts.Properties.ExcludeAdditionalProperties = val);
-                SetProperty.IfProvided<string>(config.PropertiesColumn, "DictionaryElementName", (val) => opts.Properties.DictionaryElementName = val);
-                SetProperty.IfProvided<string>(config.PropertiesColumn, "ItemElementName", (val) => opts.Properties.ItemElementName = val);
-                SetProperty.IfProvided<bool>(config.PropertiesColumn, "OmitDictionaryContainerElement", (val) => opts.Properties.OmitDictionaryContainerElement = val);
-                SetProperty.IfProvided<bool>(config.PropertiesColumn, "OmitSequenceContainerElement", (val) => opts.Properties.OmitSequenceContainerElement = val);
-                SetProperty.IfProvided<bool>(config.PropertiesColumn, "OmitStructureContainerElement", (val) => opts.Properties.OmitStructureContainerElement = val);
-                SetProperty.IfProvided<bool>(config.PropertiesColumn, "OmitElementIfEmpty", (val) => opts.Properties.OmitElementIfEmpty = val);
-                SetProperty.IfProvided<string>(config.PropertiesColumn, "PropertyElementName", (val) => opts.Properties.PropertyElementName = val);
-                SetProperty.IfProvided<string>(config.PropertiesColumn, "RootElementName", (val) => opts.Properties.RootElementName = val);
-                SetProperty.IfProvided<string>(config.PropertiesColumn, "SequenceElementName", (val) => opts.Properties.SequenceElementName = val);
-                SetProperty.IfProvided<string>(config.PropertiesColumn, "StructureElementName", (val) => opts.Properties.StructureElementName = val);
-                SetProperty.IfProvided<bool>(config.PropertiesColumn, "UsePropertyKeyAsElementName", (val) => opts.Properties.UsePropertyKeyAsElementName = val);
-
-                SetProperty.IfProvided<bool>(config.TimeStamp, "ConvertToUtc", (val) => opts.TimeStamp.ConvertToUtc = val);
-
-                // Standard Columns are subclasses of the SqlColumn class
-                void SetCommonColumnOptions(ColumnConfig source, SqlColumn target)
-                {
-                    SetProperty.IfProvidedNotEmpty<string>(source, "ColumnName", (val) => target.ColumnName = val);
-                    SetProperty.IfProvided<string>(source, "DataType", (val) => target.SetDataTypeFromConfigString(val));
-                    SetProperty.IfProvided<bool>(source, "AllowNull", (val) => target.AllowNull = val);
-                    SetProperty.IfProvided<int>(source, "DataLength", (val) => target.DataLength = val);
-                    SetProperty.IfProvided<bool>(source, "NonClusteredIndex", (val) => target.NonClusteredIndex = val);
-                }
-            }
-
-            void ReadMiscColumnOptions()
-            {
-                SetProperty.IfProvided<bool>(config, "DisableTriggers", (val) => opts.DisableTriggers = val);
-                SetProperty.IfProvided<bool>(config, "ClusteredColumnstoreIndex", (val) => opts.ClusteredColumnstoreIndex = val);
-
-                string pkName = null;
-                SetProperty.IfProvidedNotEmpty<string>(config, "PrimaryKeyColumnName", (val) => pkName = val);
-                if (pkName != null)
-                {
-                    if (opts.ClusteredColumnstoreIndex)
-                        throw new ArgumentException("SQL Clustered Columnstore Indexes and primary key constraints are mutually exclusive.");
-
-                    foreach (var standardCol in opts.Store)
-                    {
-                        var stdColOpts = opts.GetStandardColumnOptions(standardCol);
-                        if (pkName.Equals(stdColOpts.ColumnName, StringComparison.InvariantCultureIgnoreCase))
-                        {
-                            opts.PrimaryKey = stdColOpts;
-                            break;
-                        }
-                    }
-
-                    if (opts.PrimaryKey == null && opts.AdditionalColumns != null)
-                    {
-                        foreach (var col in opts.AdditionalColumns)
-                        {
-                            if (pkName.Equals(col.ColumnName, StringComparison.InvariantCultureIgnoreCase))
-                            {
-                                opts.PrimaryKey = col;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (opts.PrimaryKey == null)
-                        throw new ArgumentException($"Could not match the configured primary key column name \"{pkName}\" with a data column in the table.");
-                }
-            }
-        }
+        internal static ColumnOptions ConfigureColumnOptions(MSSqlServerConfigurationSection config, ColumnOptions columnOptions) =>
+            ColumnOptionsProvider.ConfigureColumnOptions(config, columnOptions);
     }
 }

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/ApplySystemConfiguration.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/ApplySystemConfiguration.cs
@@ -8,7 +8,7 @@ namespace Serilog.Sinks.MSSqlServer
     /// </summary>
     internal static class ApplySystemConfiguration
     {
-        internal static IConnectionStringProvider ConnectionStringProvider { get; set; } = new SystemConfigurationConnectionStringProvider();
+        internal static ISystemConfigurationConnectionStringProvider ConnectionStringProvider { get; set; } = new SystemConfigurationConnectionStringProvider();
 
         internal static ISystemConfigurationColumnOptionsProvider ColumnOptionsProvider { get; set; } = new SystemConfigurationColumnOptionsProvider();
 

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/ISystemConfigurationColumnOptionsProvider.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/ISystemConfigurationColumnOptionsProvider.cs
@@ -1,0 +1,9 @@
+﻿using Serilog.Configuration;
+
+namespace Serilog.Sinks.MSSqlServer.Configuration
+{
+    internal interface ISystemConfigurationColumnOptionsProvider
+    {
+        ColumnOptions ConfigureColumnOptions(MSSqlServerConfigurationSection config, ColumnOptions columnOptions);
+    }
+}

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/ISystemConfigurationConnectionStringProvider.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/ISystemConfigurationConnectionStringProvider.cs
@@ -1,6 +1,6 @@
 ﻿namespace Serilog.Sinks.MSSqlServer.Configuration
 {
-    internal interface IConnectionStringProvider
+    internal interface ISystemConfigurationConnectionStringProvider
     {
         string GetConnectionString(string nameOrConnectionString);
     }

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/SystemConfigurationColumnOptionsProvider.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/SystemConfigurationColumnOptionsProvider.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using Serilog.Configuration;
+
+namespace Serilog.Sinks.MSSqlServer.Configuration
+{
+    internal class SystemConfigurationColumnOptionsProvider : ISystemConfigurationColumnOptionsProvider
+    {
+        public ColumnOptions ConfigureColumnOptions(MSSqlServerConfigurationSection config, ColumnOptions columnOptions)
+        {
+            columnOptions = columnOptions ?? new ColumnOptions();
+
+            AddRmoveStandardColumns(config, columnOptions);
+            AddAdditionalColumns(config, columnOptions);
+            ReadStandardColumns(config, columnOptions);
+            ReadMiscColumnOptions(config, columnOptions);
+
+            return columnOptions;
+        }
+
+        private void AddRmoveStandardColumns(MSSqlServerConfigurationSection config, ColumnOptions columnOptions)
+        {
+            // add standard columns
+            if (config.AddStandardColumns.Count > 0)
+            {
+                foreach (StandardColumnConfig col in config.AddStandardColumns)
+                {
+                    if (Enum.TryParse(col.Name, ignoreCase: true, result: out StandardColumn stdcol)
+                        && !columnOptions.Store.Contains(stdcol))
+                        columnOptions.Store.Add(stdcol);
+                }
+            }
+
+            // remove standard columns
+            if (config.RemoveStandardColumns.Count > 0)
+            {
+                foreach (StandardColumnConfig col in config.RemoveStandardColumns)
+                {
+                    if (Enum.TryParse(col.Name, ignoreCase: true, result: out StandardColumn stdcol)
+                        && columnOptions.Store.Contains(stdcol))
+                        columnOptions.Store.Remove(stdcol);
+                }
+            }
+        }
+
+        private void AddAdditionalColumns(MSSqlServerConfigurationSection config, ColumnOptions columnOptions)
+        {
+            if (config.Columns.Count > 0)
+            {
+                foreach (ColumnConfig c in config.Columns)
+                {
+                    if (!string.IsNullOrWhiteSpace(c.ColumnName))
+                    {
+                        if (columnOptions.AdditionalColumns == null)
+                            columnOptions.AdditionalColumns = new Collection<SqlColumn>();
+
+                        columnOptions.AdditionalColumns.Add(c.AsSqlColumn());
+                    }
+                }
+
+            }
+        }
+
+        private void ReadStandardColumns(MSSqlServerConfigurationSection config, ColumnOptions columnOptions)
+        {
+            SetCommonColumnOptions(config.Exception, columnOptions.Exception);
+            SetCommonColumnOptions(config.Id, columnOptions.Id);
+            SetCommonColumnOptions(config.Level, columnOptions.Level);
+            SetCommonColumnOptions(config.LogEvent, columnOptions.LogEvent);
+            SetCommonColumnOptions(config.Message, columnOptions.Message);
+            SetCommonColumnOptions(config.MessageTemplate, columnOptions.MessageTemplate);
+            SetCommonColumnOptions(config.PropertiesColumn, columnOptions.Properties);
+            SetCommonColumnOptions(config.TimeStamp, columnOptions.TimeStamp);
+
+            SetProperty.IfProvided<bool>(config.Level, nameof(columnOptions.Level.StoreAsEnum),
+                value => columnOptions.Level.StoreAsEnum = value);
+
+            SetProperty.IfProvided<bool>(config.LogEvent, nameof(columnOptions.LogEvent.ExcludeStandardColumns),
+                value => columnOptions.LogEvent.ExcludeStandardColumns = value);
+            SetProperty.IfProvided<bool>(config.LogEvent, nameof(columnOptions.LogEvent.ExcludeAdditionalProperties),
+                value => columnOptions.LogEvent.ExcludeAdditionalProperties = value);
+
+            ReadPropertiesColumnOptions(config, columnOptions);
+
+            SetProperty.IfProvided<bool>(config.TimeStamp, nameof(columnOptions.TimeStamp.ConvertToUtc),
+                value => columnOptions.TimeStamp.ConvertToUtc = value);
+        }
+
+        private void SetCommonColumnOptions(ColumnConfig source, SqlColumn target)
+        {
+            SetProperty.IfProvidedNotEmpty<string>(source, nameof(target.ColumnName), value => target.ColumnName = value);
+            SetProperty.IfProvided<string>(source, nameof(target.DataType), value => target.SetDataTypeFromConfigString(value));
+            SetProperty.IfProvided<bool>(source, nameof(target.AllowNull), value => target.AllowNull = value);
+            SetProperty.IfProvided<int>(source, nameof(target.DataLength), value => target.DataLength = value);
+            SetProperty.IfProvided<bool>(source, nameof(target.NonClusteredIndex), value => target.NonClusteredIndex = value);
+        }
+
+        private void ReadPropertiesColumnOptions(MSSqlServerConfigurationSection config, ColumnOptions columnOptions)
+        {
+            SetProperty.IfProvided<bool>(config.PropertiesColumn, nameof(columnOptions.Properties.ExcludeAdditionalProperties),
+                value => columnOptions.Properties.ExcludeAdditionalProperties = value);
+            SetProperty.IfProvided<string>(config.PropertiesColumn, nameof(columnOptions.Properties.DictionaryElementName),
+                value => columnOptions.Properties.DictionaryElementName = value);
+            SetProperty.IfProvided<string>(config.PropertiesColumn, nameof(columnOptions.Properties.ItemElementName),
+                value => columnOptions.Properties.ItemElementName = value);
+            SetProperty.IfProvided<bool>(config.PropertiesColumn, nameof(columnOptions.Properties.OmitDictionaryContainerElement),
+                value => columnOptions.Properties.OmitDictionaryContainerElement = value);
+            SetProperty.IfProvided<bool>(config.PropertiesColumn, nameof(columnOptions.Properties.OmitSequenceContainerElement),
+                value => columnOptions.Properties.OmitSequenceContainerElement = value);
+            SetProperty.IfProvided<bool>(config.PropertiesColumn, nameof(columnOptions.Properties.OmitStructureContainerElement),
+                value => columnOptions.Properties.OmitStructureContainerElement = value);
+            SetProperty.IfProvided<bool>(config.PropertiesColumn, nameof(columnOptions.Properties.OmitElementIfEmpty),
+                value => columnOptions.Properties.OmitElementIfEmpty = value);
+            SetProperty.IfProvided<string>(config.PropertiesColumn, nameof(columnOptions.Properties.PropertyElementName),
+                value => columnOptions.Properties.PropertyElementName = value);
+            SetProperty.IfProvided<string>(config.PropertiesColumn, nameof(columnOptions.Properties.RootElementName),
+                value => columnOptions.Properties.RootElementName = value);
+            SetProperty.IfProvided<string>(config.PropertiesColumn, nameof(columnOptions.Properties.SequenceElementName),
+                value => columnOptions.Properties.SequenceElementName = value);
+            SetProperty.IfProvided<string>(config.PropertiesColumn, nameof(columnOptions.Properties.StructureElementName),
+                value => columnOptions.Properties.StructureElementName = value);
+            SetProperty.IfProvided<bool>(config.PropertiesColumn, nameof(columnOptions.Properties.UsePropertyKeyAsElementName),
+                value => columnOptions.Properties.UsePropertyKeyAsElementName = value);
+        }
+
+        private void ReadMiscColumnOptions(MSSqlServerConfigurationSection config, ColumnOptions columnOptions)
+        {
+            SetProperty.IfProvided<bool>(config, nameof(columnOptions.DisableTriggers), value => columnOptions.DisableTriggers = value);
+            SetProperty.IfProvided<bool>(config, nameof(columnOptions.ClusteredColumnstoreIndex), value => columnOptions.ClusteredColumnstoreIndex = value);
+
+            string pkName = null;
+            SetProperty.IfProvidedNotEmpty<string>(config, "PrimaryKeyColumnName", value => pkName = value);
+            if (pkName != null)
+            {
+                if (columnOptions.ClusteredColumnstoreIndex)
+                    throw new ArgumentException("SQL Clustered Columnstore Indexes and primary key constraints are mutually exclusive.");
+
+                foreach (var standardCol in columnOptions.Store)
+                {
+                    var stdColOpts = columnOptions.GetStandardColumnOptions(standardCol);
+                    if (pkName.Equals(stdColOpts.ColumnName, StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        columnOptions.PrimaryKey = stdColOpts;
+                        break;
+                    }
+                }
+
+                if (columnOptions.PrimaryKey == null && columnOptions.AdditionalColumns != null)
+                {
+                    foreach (var col in columnOptions.AdditionalColumns)
+                    {
+                        if (pkName.Equals(col.ColumnName, StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            columnOptions.PrimaryKey = col;
+                            break;
+                        }
+                    }
+                }
+
+                if (columnOptions.PrimaryKey == null)
+                    throw new ArgumentException($"Could not match the configured primary key column name \"{pkName}\" with a data column in the table.");
+            }
+        }
+    }
+}

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/SystemConfigurationConnectionStringProvider.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/SystemConfigurationConnectionStringProvider.cs
@@ -1,0 +1,28 @@
+﻿using System.Configuration;
+using Serilog.Debugging;
+
+namespace Serilog.Sinks.MSSqlServer.Configuration
+{
+    internal class SystemConfigurationConnectionStringProvider : IConnectionStringProvider
+    {
+        public string GetConnectionString(string nameOrConnectionString)
+        {
+            // If there is an `=`, we assume this is a raw connection string not a named value
+            // If there are no `=`, attempt to pull the named value from config
+            if (nameOrConnectionString.IndexOf('=') < 0)
+            {
+                var cs = ConfigurationManager.ConnectionStrings[nameOrConnectionString];
+                if (cs != null)
+                {
+                    return cs.ConnectionString;
+                }
+                else
+                {
+                    SelfLog.WriteLine("MSSqlServer sink configured value {0} is not found in ConnectionStrings settings and does not appear to be a raw connection string.", nameOrConnectionString);
+                }
+            }
+
+            return nameOrConnectionString;
+        }
+    }
+}

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/SystemConfigurationConnectionStringProvider.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/SystemConfigurationConnectionStringProvider.cs
@@ -3,7 +3,7 @@ using Serilog.Debugging;
 
 namespace Serilog.Sinks.MSSqlServer.Configuration
 {
-    internal class SystemConfigurationConnectionStringProvider : IConnectionStringProvider
+    internal class SystemConfigurationConnectionStringProvider : ISystemConfigurationConnectionStringProvider
     {
         public string GetConnectionString(string nameOrConnectionString)
         {

--- a/src/Serilog.Sinks.MSSqlServer/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Properties/AssemblyInfo.cs
@@ -10,3 +10,8 @@ using System.Runtime.CompilerServices;
                                                                          "d18dbf6d5a25af5ce9016f281014d79dc3b4201ac646c451830fc7e61a2dfd633d34c39f87b818" +
                                                                          "94191652df5ac63cc40c77f3542f702bda692e6e8a9158353df189007a49da0f3cfd55eb250066" +
                                                                          "b19485ec")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99" +
+                                                                  "c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654" +
+                                                                  "753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46" +
+                                                                  "ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484c" +
+                                                                  "f7045cc7")]

--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A Serilog sink that writes events to Microsoft SQL Server</Description>
-    <VersionPrefix>5.2.0</VersionPrefix>
+    <VersionPrefix>5.2.1</VersionPrefix>
     <Authors>Michiel van Oudheusden;Serilog Contributors</Authors>
     <TargetFrameworks>netstandard2.0;net452;netcoreapp2.0;net461</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Implementations/Microsoft.Extensions.Configuration/ApplyMicrosoftExtensionsConfigurationTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Implementations/Microsoft.Extensions.Configuration/ApplyMicrosoftExtensionsConfigurationTests.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.Extensions.Configuration;
+using Moq;
+using Serilog.Sinks.MSSqlServer.Configuration;
+using Xunit;
+
+namespace Serilog.Sinks.MSSqlServer.Tests.Configuration.Implementations.Microsoft.Extensions.Configuration
+{
+    public class ApplyMicrosoftExtensionsConfigurationTests
+    {
+        [Fact]
+        public void InitializesSystemConfigurationConnectionStringProvider()
+        {
+            Assert.NotNull(ApplyMicrosoftExtensionsConfiguration.ConnectionStringProvider);
+            Assert.IsType<MicrosoftExtensionsConnectionStringProvider>(ApplyMicrosoftExtensionsConfiguration.ConnectionStringProvider);
+        }
+
+        [Fact]
+        public void InitializesSystemConfigurationColumnOptionsProvider()
+        {
+            Assert.NotNull(ApplyMicrosoftExtensionsConfiguration.ColumnOptionsProvider);
+            Assert.IsType<MicrosoftExtensionsColumnOptionsProvider>(ApplyMicrosoftExtensionsConfiguration.ColumnOptionsProvider);
+        }
+
+        [Fact]
+        public void GetConfigurationStringCallsAttachedConfigurationStringProvider()
+        {
+            // Arrange
+            const string connectionStringName = "TestConnectionStringName";
+            const string expectedResult = "TestConnectionString";
+            var configurationMock = new Mock<IConfiguration>();
+            var connectionStringProviderMock = new Mock<IMicrosoftExtensionsConnectionStringProvider>();
+            connectionStringProviderMock.Setup(p => p.GetConnectionString(It.IsAny<string>(), It.IsAny<IConfiguration>())).Returns(expectedResult);
+            ApplyMicrosoftExtensionsConfiguration.ConnectionStringProvider = connectionStringProviderMock.Object;
+
+            // Act
+            var result = ApplyMicrosoftExtensionsConfiguration.GetConnectionString(connectionStringName, configurationMock.Object);
+
+            // Assert
+            connectionStringProviderMock.Verify(p => p.GetConnectionString(connectionStringName, configurationMock.Object), Times.Once);
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void ConfigureColumnOptionsCallsAttachedColumnOptionsProvider()
+        {
+            // Arrange
+            var inputColumnOptions = new ColumnOptions();
+            var expectedResult = new ColumnOptions();
+            var configurationSectionMock = new Mock<IConfigurationSection>();
+            var columnOptionsProviderMock = new Mock<IMicrosoftExtensionsColumnOptionsProvider>();
+            columnOptionsProviderMock.Setup(p => p.ConfigureColumnOptions(It.IsAny<ColumnOptions>(), It.IsAny<IConfigurationSection>()))
+                .Returns(expectedResult);
+            ApplyMicrosoftExtensionsConfiguration.ColumnOptionsProvider = columnOptionsProviderMock.Object;
+
+            // Act
+            var result = ApplyMicrosoftExtensionsConfiguration.ConfigureColumnOptions(inputColumnOptions, configurationSectionMock.Object);
+
+            // Assert
+            columnOptionsProviderMock.Verify(p => p.ConfigureColumnOptions(inputColumnOptions, configurationSectionMock.Object), Times.Once);
+            Assert.Same(expectedResult, result);
+        }
+    }
+}

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Implementations/System.Configuration/ApplySystemConfigurationTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Implementations/System.Configuration/ApplySystemConfigurationTests.cs
@@ -27,7 +27,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Configuration.Implementations.System.C
             // Arrange
             const string connectionStringName = "TestConnectionStringName";
             const string expectedResult = "TestConnectionString";
-            var connectionStringProviderMock = new Mock<IConnectionStringProvider>();
+            var connectionStringProviderMock = new Mock<ISystemConfigurationConnectionStringProvider>();
             connectionStringProviderMock.Setup(p => p.GetConnectionString(It.IsAny<string>())).Returns(expectedResult);
             ApplySystemConfiguration.ConnectionStringProvider = connectionStringProviderMock.Object;
 

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Implementations/System.Configuration/ApplySystemConfigurationTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Implementations/System.Configuration/ApplySystemConfigurationTests.cs
@@ -1,0 +1,62 @@
+﻿using Moq;
+using Serilog.Configuration;
+using Serilog.Sinks.MSSqlServer.Configuration;
+using Xunit;
+
+namespace Serilog.Sinks.MSSqlServer.Tests.Configuration.Implementations.System.Configuration
+{
+    public class ApplySystemConfigurationTests
+    {
+        [Fact]
+        public void InitializesSystemConfigurationConnectionStringProvider()
+        {
+            Assert.NotNull(ApplySystemConfiguration.ConnectionStringProvider);
+            Assert.IsType<SystemConfigurationConnectionStringProvider>(ApplySystemConfiguration.ConnectionStringProvider);
+        }
+
+        [Fact]
+        public void InitializesSystemConfigurationColumnOptionsProvider()
+        {
+            Assert.NotNull(ApplySystemConfiguration.ColumnOptionsProvider);
+            Assert.IsType<SystemConfigurationColumnOptionsProvider>(ApplySystemConfiguration.ColumnOptionsProvider);
+        }
+
+        [Fact]
+        public void GetConfigurationStringCallsAttachedConfigurationStringProvider()
+        {
+            // Arrange
+            const string connectionStringName = "TestConnectionStringName";
+            const string expectedResult = "TestConnectionString";
+            var connectionStringProviderMock = new Mock<IConnectionStringProvider>();
+            connectionStringProviderMock.Setup(p => p.GetConnectionString(It.IsAny<string>())).Returns(expectedResult);
+            ApplySystemConfiguration.ConnectionStringProvider = connectionStringProviderMock.Object;
+
+            // Act
+            var result = ApplySystemConfiguration.GetConnectionString(connectionStringName);
+
+            // Assert
+            connectionStringProviderMock.Verify(p => p.GetConnectionString(connectionStringName), Times.Once);
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void ConfigureColumnOptionsCallsAttachedColumnOptionsProvider()
+        {
+            // Arrange
+            var inputConfigSection = new MSSqlServerConfigurationSection();
+            var inputColumnOptions = new ColumnOptions();
+            var expectedResult = new ColumnOptions();
+            var columnOptionsProviderMock = new Mock<ISystemConfigurationColumnOptionsProvider>();
+            columnOptionsProviderMock.Setup(p => p.ConfigureColumnOptions(It.IsAny<MSSqlServerConfigurationSection>(), It.IsAny<ColumnOptions>()))
+                .Returns(expectedResult);
+            ApplySystemConfiguration.ColumnOptionsProvider = columnOptionsProviderMock.Object;
+
+            // Act
+            var result = ApplySystemConfiguration.ConfigureColumnOptions(inputConfigSection, inputColumnOptions);
+
+            // Assert
+            columnOptionsProviderMock.Verify(p => p.ConfigureColumnOptions(inputConfigSection, inputColumnOptions), Times.Once);
+            Assert.Same(expectedResult, result);
+        }
+    }
+}

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Microsoft.Extensions.Configuration/ConfigurationExtensionsTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Microsoft.Extensions.Configuration/ConfigurationExtensionsTests.cs
@@ -10,7 +10,7 @@ using System;
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Collection("LogTest")]
-    public sealed class ConfigurationExtensions : IDisposable
+    public sealed class ConfigurationExtensionsTests : IDisposable
     {
         static string ConnectionStringName = "NamedConnection";
         static string ColumnOptionsSection = "CustomColumnNames";

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/System.Configuration/ConfigurationExtensionsTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/System.Configuration/ConfigurationExtensionsTests.cs
@@ -16,7 +16,7 @@ using System.Linq;
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Collection("LogTest")]
-    public class ConfigurationExtensions : IDisposable
+    public sealed class ConfigurationExtensionsTests : IDisposable
     {
         [Fact]
         public void ConnectionStringByName()

--- a/test/Serilog.Sinks.MSSqlServer.Tests/IndexingFeaturesTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/IndexingFeaturesTests.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Data;
 using System.Data.SqlClient;
 using System.Linq;
 using Dapper;
@@ -10,7 +8,7 @@ using Xunit;
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Collection("LogTest")]
-    public class TestIndexingFeatures : IDisposable
+    public sealed class IndexingFeaturesTests : IDisposable
     {
         [Fact]
         public void NonClusteredDefaultIdPrimaryKey()

--- a/test/Serilog.Sinks.MSSqlServer.Tests/LevelAsEnumTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/LevelAsEnumTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Collection("LogTest")]
-    public class LevelAsEnum : IDisposable
+    public sealed class LevelAsEnumTests : IDisposable
     {
         [Fact]
         public void CanStoreLevelAsEnum()

--- a/test/Serilog.Sinks.MSSqlServer.Tests/MiscFeaturesTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/MiscFeaturesTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Collection("LogTest")]
-    public sealed class TestMiscFeatures : IDisposable
+    public sealed class MiscFeaturesTests : IDisposable
     {
         [Fact]
         public void LogEventExcludeAdditionalProperties()

--- a/test/Serilog.Sinks.MSSqlServer.Tests/PropertiesColumnFilteringTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/PropertiesColumnFilteringTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Collection("LogTest")]
-    public class PropertiesColumnFilteringTests : IDisposable
+    public sealed class PropertiesColumnFilteringTests : IDisposable
     {
         [Fact]
         public void FilteredProperties()

--- a/test/Serilog.Sinks.MSSqlServer.Tests/PropertiesColumnFilteringTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/PropertiesColumnFilteringTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Collection("LogTest")]
-    public class TestPropertiesColumnFiltering : IDisposable
+    public class PropertiesColumnFilteringTests : IDisposable
     {
         [Fact]
         public void FilteredProperties()

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Serilog.Sinks.MSSqlServer.Tests.csproj
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Serilog.Sinks.MSSqlServer.Tests.csproj
@@ -65,6 +65,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <Compile Include="Configuration\Microsoft.Extensions.Configuration\**\*.cs" />
+    <Compile Include="Configuration\Implementations\Microsoft.Extensions.Configuration\**\*.cs" />
     <Compile Include="Configuration\Implementations\System.Configuration\**\*.cs" />
   </ItemGroup>
 

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Serilog.Sinks.MSSqlServer.Tests.csproj
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Serilog.Sinks.MSSqlServer.Tests.csproj
@@ -48,6 +48,7 @@
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <Compile Include="Configuration\System.Configuration\**\*.cs" />
+    <Compile Include="Configuration\Implementations\System.Configuration\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
@@ -64,6 +65,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <Compile Include="Configuration\Microsoft.Extensions.Configuration\**\*.cs" />
+    <Compile Include="Configuration\Implementations\System.Configuration\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/ColumnOptions/TimeStampColumnOptionsTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/ColumnOptions/TimeStampColumnOptionsTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Serilog.Sinks.MSSqlServer.Tests.Sinks.MSSqlServer.ColumnOptions
 {
-    public class TestTimeStampColumnOptions
+    public class TimeStampColumnOptionsTests
     {
         [Trait("Bugfix", "#187")]
         [Fact]

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/MSSqlServerSinkTraitsTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/MSSqlServerSinkTraitsTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Serilog.Sinks.MSSqlServer.Tests.Sinks.MSSqlServer
 {
-    public class TestMSSqlServerSinkTraits
+    public class MSSqlServerSinkTraitsTests
     {
         private MSSqlServerSinkTraits traits;
         private LogEvent logEvent;

--- a/test/Serilog.Sinks.MSSqlServer.Tests/SqlTypesTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/SqlTypesTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Collection("LogTest")]
-    public sealed class TestSqlTypes : IDisposable
+    public sealed class SqlTypesTests : IDisposable
     {
         // Since the point of these tests are to validate we can write to
         // specific underlying SQL Server column data types, we use audit

--- a/test/Serilog.Sinks.MSSqlServer.Tests/TimeStampTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/TimeStampTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Data;
 using System.Data.SqlClient;
+using System.IO;
 using Dapper;
 using FluentAssertions;
 using Xunit;
@@ -7,10 +9,11 @@ using Xunit;
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Collection("LogTest")]
-    public class TestTriggersOnLogTable : IDisposable
+    public class TimeStampTests : IDisposable
     {
+        [Trait("Bugfix", "#187")]
         [Fact]
-        public void TestTriggerOnLogTableFire()
+        public void CanCreateDatabaseWithDateTimeByDefault()
         {
             // arrange
             var loggerConfiguration = new LoggerConfiguration();
@@ -23,28 +26,24 @@ namespace Serilog.Sinks.MSSqlServer.Tests
                 columnOptions: new ColumnOptions())
                 .CreateLogger();
 
-            CreateTrigger();
-
             // act
             const string loggingInformationMessage = "Logging Information message";
             Log.Information(loggingInformationMessage);
-
             Log.CloseAndFlush();
 
             // assert
             using (var conn = new SqlConnection(DatabaseFixture.LogEventsConnectionString))
             {
-                var logTriggerEvents = conn.Query<TestTriggerEntry>($"SELECT * FROM {logTriggerTableName}");
-
-                logTriggerEvents.Should().NotBeNullOrEmpty();
+                var logEvents = conn.Query<TestTimeStampDateTimeEntry>($"SELECT TimeStamp FROM {DatabaseFixture.LogTableName}");
+                logEvents.Should().NotBeEmpty();
             }
         }
 
+        [Trait("Bugfix", "#187")]
         [Fact]
-        public void TestOptionsDisableTriggersOnLogTable()
+        public void CanStoreDateTimeOffsetWithCorrectLocalTimeZone()
         {
             // arrange
-            var options = new ColumnOptions { DisableTriggers = true };
             var loggerConfiguration = new LoggerConfiguration();
             Log.Logger = loggerConfiguration.WriteTo.MSSqlServer(
                 connectionString: DatabaseFixture.LogEventsConnectionString,
@@ -52,94 +51,54 @@ namespace Serilog.Sinks.MSSqlServer.Tests
                 autoCreateSqlTable: true,
                 batchPostingLimit: 1,
                 period: TimeSpan.FromSeconds(10),
-                columnOptions: options)
+                columnOptions: new ColumnOptions { TimeStamp = { DataType = SqlDbType.DateTimeOffset, ConvertToUtc = false }})
                 .CreateLogger();
-
-            CreateTrigger();
+            var dateTimeOffsetNow = DateTimeOffset.Now;
 
             // act
             const string loggingInformationMessage = "Logging Information message";
             Log.Information(loggingInformationMessage);
-
             Log.CloseAndFlush();
 
             // assert
             using (var conn = new SqlConnection(DatabaseFixture.LogEventsConnectionString))
             {
-                var logTriggerEvents = conn.Query<TestTriggerEntry>($"SELECT * FROM {logTriggerTableName}");
-
-                logTriggerEvents.Should().BeEmpty();
+                var logEvents = conn.Query<TestTimeStampDateTimeOffsetEntry>($"SELECT TimeStamp FROM {DatabaseFixture.LogTableName}");
+                logEvents.Should().Contain(e => e.TimeStamp.Offset == dateTimeOffsetNow.Offset);
             }
         }
 
+        [Trait("Bugfix", "#187")]
         [Fact]
-        public void TestAuditTriggerOnLogTableFire()
+        public void CanStoreDateTimeOffsetWithUtcTimeZone()
         {
             // arrange
             var loggerConfiguration = new LoggerConfiguration();
-            Log.Logger = loggerConfiguration.AuditTo.MSSqlServer(
+            Log.Logger = loggerConfiguration.WriteTo.MSSqlServer(
                 connectionString: DatabaseFixture.LogEventsConnectionString,
                 tableName: DatabaseFixture.LogTableName,
                 autoCreateSqlTable: true,
-                columnOptions: new ColumnOptions())
+                batchPostingLimit: 1,
+                period: TimeSpan.FromSeconds(10),
+                columnOptions: new ColumnOptions { TimeStamp = { DataType = SqlDbType.DateTimeOffset, ConvertToUtc = true } })
                 .CreateLogger();
-
-            CreateTrigger();
 
             // act
             const string loggingInformationMessage = "Logging Information message";
             Log.Information(loggingInformationMessage);
-
             Log.CloseAndFlush();
 
             // assert
             using (var conn = new SqlConnection(DatabaseFixture.LogEventsConnectionString))
             {
-                var logTriggerEvents = conn.Query<TestTriggerEntry>($"SELECT * FROM {logTriggerTableName}");
-
-                logTriggerEvents.Should().NotBeNullOrEmpty();
-            }
-        }
-
-        [Fact]        
-        public void TestAuditOptionsDisableTriggersOnLogTable_ThrowsNotSupportedException()
-        {
-            // arrange
-            var options = new ColumnOptions { DisableTriggers = true };
-            var loggerConfiguration = new LoggerConfiguration();
-            Assert.Throws<NotSupportedException>(() => loggerConfiguration.AuditTo.MSSqlServer(
-                connectionString: DatabaseFixture.LogEventsConnectionString,
-                tableName: DatabaseFixture.LogTableName,
-                autoCreateSqlTable: true,
-                columnOptions: options)
-                .CreateLogger());
-
-            // throws, should be no table to delete unless the test fails
-            DatabaseFixture.DropTable();
-        }
-
-        private string logTriggerTableName => $"{DatabaseFixture.LogTableName}Trigger";
-        private string logTriggerName => $"{logTriggerTableName}Trigger";
-
-        private void CreateTrigger()
-        {
-            using (var conn = new SqlConnection(DatabaseFixture.LogEventsConnectionString))
-            {
-                conn.Execute($"CREATE TABLE {logTriggerTableName} ([Id] [UNIQUEIDENTIFIER] NOT NULL, [Data] [NVARCHAR](50) NOT NULL)");
-                conn.Execute($@"
-CREATE TRIGGER {logTriggerName} ON {DatabaseFixture.LogTableName} 
-AFTER INSERT 
-AS
-BEGIN 
-INSERT INTO {logTriggerTableName} VALUES (NEWID(), 'Data') 
-END");
+                var logEvents = conn.Query<TestTimeStampDateTimeOffsetEntry>($"SELECT TimeStamp FROM {DatabaseFixture.LogTableName}");
+                logEvents.Should().Contain(e => e.TimeStamp.Offset == new TimeSpan(0));
             }
         }
 
         public void Dispose()
         {
             DatabaseFixture.DropTable();
-            DatabaseFixture.DropTable(logTriggerTableName);
         }
     }
 }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/TimeStampTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/TimeStampTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Data;
 using System.Data.SqlClient;
-using System.IO;
 using Dapper;
 using FluentAssertions;
 using Xunit;
@@ -9,7 +8,7 @@ using Xunit;
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Collection("LogTest")]
-    public class TimeStampTests : IDisposable
+    public sealed class TimeStampTests : IDisposable
     {
         [Trait("Bugfix", "#187")]
         [Fact]

--- a/test/Serilog.Sinks.MSSqlServer.Tests/TriggersOnLogTableTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/TriggersOnLogTableTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
     [Collection("LogTest")]
-    public class TriggersOnLogTableTests : IDisposable
+    public sealed class TriggersOnLogTableTests : IDisposable
     {
         [Fact]
         public void TestTriggerOnLogTableFire()


### PR DESCRIPTION
* Decomposed ApplySystemConfiguration and ApplyMicrosoftExtensionsConfiguration classes into separate testable classes and added tests.
* Renamed all test classes to match the more common scheme with -Tests suffix instead of Test- prefix.
* Made all classes implementing IDisposable sealed to avoid problems with the pattern in derived classes.
* Updated changelog.