### PR TITLE
Corrections and do not mute exceptions during database tests.

### DIFF
--- a/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Extensions/Microsoft.Extensions.Configuration/ConfigurationExtensionsTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Extensions/Microsoft.Extensions.Configuration/ConfigurationExtensionsTests.cs
@@ -64,10 +64,8 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Configuration.Extensions.Microsoft.Ext
                 .CreateLogger();
             Log.CloseAndFlush();
 
-            // from test TableCreatedWithCustomNames in CustomStandardColumnNames class
-            using(var conn = new SqlConnection(DatabaseFixture.MasterConnectionString))
+            using(var conn = new SqlConnection(DatabaseFixture.LogEventsConnectionString))
             {
-                conn.Execute($"use {DatabaseFixture.Database}");
                 var logEvents = conn.Query<InfoSchema>($@"SELECT COLUMN_NAME AS ColumnName FROM {DatabaseFixture.Database}.INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{DatabaseFixture.LogTableName}'");
                 var infoSchema = logEvents as InfoSchema[] ?? logEvents.ToArray();
 

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Extensions/System.Configuration/ConfigurationExtensionsTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Extensions/System.Configuration/ConfigurationExtensionsTests.cs
@@ -50,10 +50,8 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Configuration.Extensions.System.Config
                 .CreateLogger();
             Log.CloseAndFlush();
 
-            // from test TableCreatedWithCustomNames in CustomStandardColumnNames class
-            using (var conn = new SqlConnection(DatabaseFixture.MasterConnectionString))
+            using (var conn = new SqlConnection(DatabaseFixture.LogEventsConnectionString))
             {
-                conn.Execute($"use {DatabaseFixture.Database}");
                 var logEvents = conn.Query<InfoSchema>($@"SELECT COLUMN_NAME AS ColumnName FROM {DatabaseFixture.Database}.INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{DatabaseFixture.LogTableName}'");
                 var infoSchema = logEvents as InfoSchema[] ?? logEvents.ToArray();
 
@@ -79,9 +77,8 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Configuration.Extensions.System.Config
                 .CreateLogger();
             Log.CloseAndFlush();
 
-            using (var conn = new SqlConnection(DatabaseFixture.MasterConnectionString))
+            using (var conn = new SqlConnection(DatabaseFixture.LogEventsConnectionString))
             {
-                conn.Execute($"use {DatabaseFixture.Database}");
                 var logEvents = conn.Query<InfoSchema>($@"SELECT COLUMN_NAME AS ColumnName FROM {DatabaseFixture.Database}.INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{DatabaseFixture.LogTableName}'");
                 var infoSchema = logEvents as InfoSchema[] ?? logEvents.ToArray();
 

--- a/test/Serilog.Sinks.MSSqlServer.Tests/CustomStandardColumnNamesTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/CustomStandardColumnNamesTests.cs
@@ -25,9 +25,8 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, true, options, "dbo", null);
 
             // assert
-            using (var conn = new SqlConnection(DatabaseFixture.MasterConnectionString))
+            using (var conn = new SqlConnection(DatabaseFixture.LogEventsConnectionString))
             {
-                conn.Execute($"use {DatabaseFixture.Database}");
                 var logEvents = conn.Query<InfoSchema>($@"SELECT COLUMN_NAME AS ColumnName FROM {DatabaseFixture.Database}.INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{DatabaseFixture.LogTableName}'");
                 var infoSchema = logEvents as InfoSchema[] ?? logEvents.ToArray();
 
@@ -53,9 +52,8 @@ namespace Serilog.Sinks.MSSqlServer.Tests
 
             // assert
             var idColumnName = "Id";
-            using (var conn = new SqlConnection(DatabaseFixture.MasterConnectionString))
+            using (var conn = new SqlConnection(DatabaseFixture.LogEventsConnectionString))
             {
-                conn.Execute($"use {DatabaseFixture.Database}");
                 var logEvents = conn.Query<InfoSchema>($@"SELECT COLUMN_NAME AS ColumnName FROM {DatabaseFixture.Database}.INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{DatabaseFixture.LogTableName}'");
                 var infoSchema = logEvents as InfoSchema[] ?? logEvents.ToArray();
 
@@ -88,9 +86,8 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, true, options, "dbo", null);
 
             // assert
-            using (var conn = new SqlConnection(DatabaseFixture.MasterConnectionString))
+            using (var conn = new SqlConnection(DatabaseFixture.LogEventsConnectionString))
             {
-                conn.Execute($"use {DatabaseFixture.Database}");
                 var logEvents = conn.Query<InfoSchema>($@"SELECT COLUMN_NAME AS ColumnName FROM {DatabaseFixture.Database}.INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{DatabaseFixture.LogTableName}'");
                 var infoSchema = logEvents as InfoSchema[] ?? logEvents.ToArray();
 
@@ -114,9 +111,8 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             var sink = new MSSqlServerSink(DatabaseFixture.LogEventsConnectionString, DatabaseFixture.LogTableName, 1, TimeSpan.FromSeconds(1), null, true, options,  "dbo", null);
 
             // assert
-            using (var conn = new SqlConnection(DatabaseFixture.MasterConnectionString))
+            using (var conn = new SqlConnection(DatabaseFixture.LogEventsConnectionString))
             {
-                conn.Execute($"use {DatabaseFixture.Database}");
                 var logEvents = conn.Query<InfoSchema>($@"SELECT COLUMN_NAME AS ColumnName FROM {DatabaseFixture.Database}.INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{DatabaseFixture.LogTableName}'");
                 var infoSchema = logEvents as InfoSchema[] ?? logEvents.ToArray();
 

--- a/test/Serilog.Sinks.MSSqlServer.Tests/MiscFeaturesTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/MiscFeaturesTests.cs
@@ -154,9 +154,8 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             Log.CloseAndFlush();
 
             // assert
-            using (var conn = new SqlConnection(DatabaseFixture.MasterConnectionString))
+            using (var conn = new SqlConnection(DatabaseFixture.LogEventsConnectionString))
             {
-                conn.Execute($"use {DatabaseFixture.Database}");
                 var query = conn.Query<InfoSchema>($@"SELECT DATA_TYPE AS DataType FROM {DatabaseFixture.Database}.INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{DatabaseFixture.LogTableName}' AND COLUMN_NAME = '{columnOptions.Id.ColumnName}'");
                 var results = query as InfoSchema[] ?? query.ToArray();
 
@@ -186,9 +185,8 @@ namespace Serilog.Sinks.MSSqlServer.Tests
             Log.CloseAndFlush();
 
             // assert
-            using (var conn = new SqlConnection(DatabaseFixture.MasterConnectionString))
+            using (var conn = new SqlConnection(DatabaseFixture.LogEventsConnectionString))
             {
-                conn.Execute($"use {DatabaseFixture.Database}");
                 var query = conn.Query<InfoSchema>($@"SELECT DATA_TYPE AS DataType FROM {DatabaseFixture.Database}.INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '{DatabaseFixture.LogTableName}' AND COLUMN_NAME = '{columnOptions.Properties.ColumnName}'");
                 var results = query as InfoSchema[] ?? query.ToArray();
 

--- a/test/Serilog.Sinks.MSSqlServer.Tests/TestUtils/DatabaseFixture.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/TestUtils/DatabaseFixture.cs
@@ -46,14 +46,11 @@ DROP DATABASE [{Database}]
 
         public static void DropTable(string tableName = null)
         {
-            try
+            using (var conn = new SqlConnection(LogEventsConnectionString))
             {
-                using (var conn = new SqlConnection(LogEventsConnectionString))
-                {
-                    conn.Execute($"DROP TABLE {(string.IsNullOrEmpty(tableName) ? LogTableName : tableName)};");
-                }
+                var actualTableName = string.IsNullOrEmpty(tableName) ? LogTableName : tableName;
+                conn.Execute($"IF OBJECT_ID('{actualTableName}', 'U') IS NOT NULL DROP TABLE {actualTableName};");
             }
-            catch { }
         }
 
         private static void DeleteDatabase()

--- a/test/Serilog.Sinks.MSSqlServer.Tests/TestUtils/DatabaseFixture.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/TestUtils/DatabaseFixture.cs
@@ -10,6 +10,8 @@ namespace Serilog.Sinks.MSSqlServer.Tests.TestUtils
         public static string Database => "LogTest";
         public static string LogTableName => "LogEvents";
 
+        private const string MasterConnectionString = @"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=Master;Integrated Security=True";
+
         private const string CreateLogEventsDatabase = @"
 EXEC ('CREATE DATABASE [{0}] ON PRIMARY 
 	(NAME = [{0}], 
@@ -26,7 +28,6 @@ WITH ROLLBACK IMMEDIATE
 DROP DATABASE [{Database}]
 ";
 
-        public static string MasterConnectionString => @"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=Master;Integrated Security=True";
         public static string LogEventsConnectionString => $@"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog={Database};Integrated Security=True";
 
         public class FileName


### PR DESCRIPTION
In DatabaseFixture for tests: drop test table only if it exists and do not silently catch exceptions.