### PR TITLE
Fixed unit test parallel execution

### DIFF
--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/Hybrid/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/Hybrid/LoggerConfigurationMSSqlServerExtensions.cs
@@ -82,8 +82,9 @@ namespace Serilog
 
             if (ConfigurationManager.GetSection(AppConfigSectionName) is MSSqlServerConfigurationSection serviceConfigSection)
             {
-                colOpts = ApplySystemConfiguration.ConfigureColumnOptions(serviceConfigSection, colOpts);
-                connStr = ApplySystemConfiguration.GetConnectionString(connStr);
+                var systemConfiguration = new ApplySystemConfiguration();
+                colOpts = systemConfiguration.ConfigureColumnOptions(serviceConfigSection, colOpts);
+                connStr = systemConfiguration.GetConnectionString(connStr);
 
                 if (appConfiguration != null || columnOptionsSection != null)
                     SelfLog.WriteLine("Warning: Both System.Configuration (app.config or web.config) and Microsoft.Extensions.Configuration are being applied to the MSSQLServer sink.");
@@ -91,8 +92,9 @@ namespace Serilog
 
             if (appConfiguration != null || columnOptionsSection != null)
             {
-                connStr = ApplyMicrosoftExtensionsConfiguration.GetConnectionString(connStr, appConfiguration);
-                colOpts = ApplyMicrosoftExtensionsConfiguration.ConfigureColumnOptions(colOpts, columnOptionsSection);
+                var microsoftExtensionsConfiguration = new ApplyMicrosoftExtensionsConfiguration();
+                connStr = microsoftExtensionsConfiguration.GetConnectionString(connStr, appConfiguration);
+                colOpts = microsoftExtensionsConfiguration.ConfigureColumnOptions(colOpts, columnOptionsSection);
             }
 
             return loggerConfiguration.Sink(
@@ -146,8 +148,9 @@ namespace Serilog
 
             if (ConfigurationManager.GetSection(AppConfigSectionName) is MSSqlServerConfigurationSection serviceConfigSection)
             {
-                colOpts = ApplySystemConfiguration.ConfigureColumnOptions(serviceConfigSection, colOpts);
-                connStr = ApplySystemConfiguration.GetConnectionString(connStr);
+                var systemConfiguration = new ApplySystemConfiguration();
+                colOpts = systemConfiguration.ConfigureColumnOptions(serviceConfigSection, colOpts);
+                connStr = systemConfiguration.GetConnectionString(connStr);
 
                 if (appConfiguration != null || columnOptionsSection != null)
                     SelfLog.WriteLine("Warning: Both System.Configuration (app.config or web.config) and Microsoft.Extensions.Configuration are being applied to the MSSQLServer sink.");
@@ -155,8 +158,9 @@ namespace Serilog
 
             if (appConfiguration != null || columnOptionsSection != null)
             {
-                connStr = ApplyMicrosoftExtensionsConfiguration.GetConnectionString(connStr, appConfiguration);
-                colOpts = ApplyMicrosoftExtensionsConfiguration.ConfigureColumnOptions(colOpts, columnOptionsSection);
+                var microsoftExtensionsConfiguration = new ApplyMicrosoftExtensionsConfiguration();
+                connStr = microsoftExtensionsConfiguration.GetConnectionString(connStr, appConfiguration);
+                colOpts = microsoftExtensionsConfiguration.ConfigureColumnOptions(colOpts, columnOptionsSection);
             }
 
             return loggerAuditSinkConfiguration.Sink(

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationMSSqlServerExtensions.cs
@@ -68,8 +68,10 @@ namespace Serilog
                 throw new ArgumentNullException(nameof(loggerConfiguration));
 
             var defaultedPeriod = period ?? MSSqlServerSink.DefaultPeriod;
-            var connectionStr = ApplyMicrosoftExtensionsConfiguration.GetConnectionString(connectionString, appConfiguration);
-            var colOpts = ApplyMicrosoftExtensionsConfiguration.ConfigureColumnOptions(columnOptions, columnOptionsSection);
+
+            var microsoftExtensionsConfiguration = new ApplyMicrosoftExtensionsConfiguration();
+            var connectionStr = microsoftExtensionsConfiguration.GetConnectionString(connectionString, appConfiguration);
+            var colOpts = microsoftExtensionsConfiguration.ConfigureColumnOptions(columnOptions, columnOptionsSection);
 
             return loggerConfiguration.Sink(
                 new MSSqlServerSink(
@@ -117,8 +119,9 @@ namespace Serilog
             if (loggerAuditSinkConfiguration == null)
                 throw new ArgumentNullException(nameof(loggerAuditSinkConfiguration));
 
-            connectionString = ApplyMicrosoftExtensionsConfiguration.GetConnectionString(connectionString, appConfiguration);
-            columnOptions = ApplyMicrosoftExtensionsConfiguration.ConfigureColumnOptions(columnOptions, columnOptionsSection);
+            var microsoftExtensionsConfiguration = new ApplyMicrosoftExtensionsConfiguration();
+            connectionString = microsoftExtensionsConfiguration.GetConnectionString(connectionString, appConfiguration);
+            columnOptions = microsoftExtensionsConfiguration.ConfigureColumnOptions(columnOptions, columnOptionsSection);
 
             return loggerAuditSinkConfiguration.Sink(
                 new MSSqlServerAuditSink(

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/System.Configuration/LoggerConfigurationMSSqlServerExtensions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Extensions/System.Configuration/LoggerConfigurationMSSqlServerExtensions.cs
@@ -71,10 +71,11 @@ namespace Serilog
             var defaultedPeriod = period ?? MSSqlServerSink.DefaultPeriod;
             var colOpts = columnOptions ?? new ColumnOptions();
 
+            var systemConfiguration = new ApplySystemConfiguration();
             if (ConfigurationManager.GetSection(AppConfigSectionName) is MSSqlServerConfigurationSection serviceConfigSection)
-                colOpts = ApplySystemConfiguration.ConfigureColumnOptions(serviceConfigSection, colOpts);
+                colOpts = systemConfiguration.ConfigureColumnOptions(serviceConfigSection, colOpts);
 
-            connectionString = ApplySystemConfiguration.GetConnectionString(connectionString);
+            connectionString = systemConfiguration.GetConnectionString(connectionString);
 
             return loggerConfiguration.Sink(
                 new MSSqlServerSink(
@@ -123,10 +124,11 @@ namespace Serilog
 
             var colOpts = columnOptions ?? new ColumnOptions();
 
+            var systemConfiguration = new ApplySystemConfiguration();
             if (ConfigurationManager.GetSection(AppConfigSectionName) is MSSqlServerConfigurationSection serviceConfigSection)
-                colOpts = ApplySystemConfiguration.ConfigureColumnOptions(serviceConfigSection, colOpts);
+                colOpts = systemConfiguration.ConfigureColumnOptions(serviceConfigSection, colOpts);
 
-            connectionString = ApplySystemConfiguration.GetConnectionString(connectionString);
+            connectionString = systemConfiguration.GetConnectionString(connectionString);
 
             return loggerAuditSinkConfiguration.Sink(
                 new MSSqlServerAuditSink(

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/Microsoft.Extensions.Configuration/ApplyMicrosoftExtensionsConfiguration.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/Microsoft.Extensions.Configuration/ApplyMicrosoftExtensionsConfiguration.cs
@@ -6,11 +6,25 @@ namespace Serilog.Sinks.MSSqlServer
     /// <summary>
     /// Configures the sink's connection string and ColumnOtions object.
     /// </summary>
-    internal static class ApplyMicrosoftExtensionsConfiguration
+    internal class ApplyMicrosoftExtensionsConfiguration
     {
-        internal static IMicrosoftExtensionsConnectionStringProvider ConnectionStringProvider { get; set; } = new MicrosoftExtensionsConnectionStringProvider();
+        private readonly IMicrosoftExtensionsConnectionStringProvider _connectionStringProvider;
+        private readonly IMicrosoftExtensionsColumnOptionsProvider _columnOptionsProvider;
 
-        internal static IMicrosoftExtensionsColumnOptionsProvider ColumnOptionsProvider { get; set; } = new MicrosoftExtensionsColumnOptionsProvider();
+        public ApplyMicrosoftExtensionsConfiguration()
+        {
+            _connectionStringProvider = new MicrosoftExtensionsConnectionStringProvider();
+            _columnOptionsProvider = new MicrosoftExtensionsColumnOptionsProvider();
+        }
+
+        // Constructor with injectable dependencies for tests
+        internal ApplyMicrosoftExtensionsConfiguration(
+            IMicrosoftExtensionsConnectionStringProvider connectionStringProvider,
+            IMicrosoftExtensionsColumnOptionsProvider columnOptionsProvider)
+        {
+            _connectionStringProvider = connectionStringProvider;
+            _columnOptionsProvider = columnOptionsProvider;
+        }
 
         /// <summary>
         /// Examine if supplied connection string is a reference to an item in the "ConnectionStrings" section of web.config
@@ -19,8 +33,8 @@ namespace Serilog.Sinks.MSSqlServer
         /// <param name="nameOrConnectionString">The name of the ConnectionStrings key or raw connection string.</param>
         /// <param name="appConfiguration">Additional application-level configuration.</param>
         /// <remarks>Pulled from review of Entity Framework 6 methodology for doing the same</remarks>
-        internal static string GetConnectionString(string nameOrConnectionString, IConfiguration appConfiguration) =>
-            ConnectionStringProvider.GetConnectionString(nameOrConnectionString, appConfiguration);
+        public string GetConnectionString(string nameOrConnectionString, IConfiguration appConfiguration) =>
+            _connectionStringProvider.GetConnectionString(nameOrConnectionString, appConfiguration);
 
         /// <summary>
         /// Create or add to the ColumnOptions object and apply any configuration changes to it.
@@ -28,7 +42,7 @@ namespace Serilog.Sinks.MSSqlServer
         /// <param name="columnOptions">An optional externally-created ColumnOptions object to be updated with additional configuration values.</param>
         /// <param name="config">A configuration section typically named "columnOptionsSection" (see docs).</param>
         /// <returns></returns>
-        internal static ColumnOptions ConfigureColumnOptions(ColumnOptions columnOptions, IConfigurationSection config) =>
-            ColumnOptionsProvider.ConfigureColumnOptions(columnOptions, config);
+        public ColumnOptions ConfigureColumnOptions(ColumnOptions columnOptions, IConfigurationSection config) =>
+            _columnOptionsProvider.ConfigureColumnOptions(columnOptions, config);
     }
 }

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/ApplySystemConfiguration.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/ApplySystemConfiguration.cs
@@ -6,11 +6,25 @@ namespace Serilog.Sinks.MSSqlServer
     /// <summary>
     /// Configures the sink's connection string and ColumnOtions object.
     /// </summary>
-    internal static class ApplySystemConfiguration
+    internal class ApplySystemConfiguration
     {
-        internal static ISystemConfigurationConnectionStringProvider ConnectionStringProvider { get; set; } = new SystemConfigurationConnectionStringProvider();
+        private readonly ISystemConfigurationConnectionStringProvider _connectionStringProvider;
+        private readonly ISystemConfigurationColumnOptionsProvider _columnOptionsProvider;
 
-        internal static ISystemConfigurationColumnOptionsProvider ColumnOptionsProvider { get; set; } = new SystemConfigurationColumnOptionsProvider();
+        public ApplySystemConfiguration()
+        {
+            _connectionStringProvider = new SystemConfigurationConnectionStringProvider();
+            _columnOptionsProvider = new SystemConfigurationColumnOptionsProvider();
+        }
+
+        // Constructor with injectable dependencies for tests
+        internal ApplySystemConfiguration(
+            ISystemConfigurationConnectionStringProvider connectionStringProvider,
+            ISystemConfigurationColumnOptionsProvider columnOptionsProvider)
+        {
+            _connectionStringProvider = connectionStringProvider;
+            _columnOptionsProvider = columnOptionsProvider;
+        }
 
         /// <summary>
         /// Examine if supplied connection string is a reference to an item in the "ConnectionStrings" section of web.config
@@ -18,13 +32,13 @@ namespace Serilog.Sinks.MSSqlServer
         /// </summary>
         /// <param name="nameOrConnectionString">The name of the ConnectionStrings key or raw connection string.</param>
         /// <remarks>Pulled from review of Entity Framework 6 methodology for doing the same</remarks>
-        internal static string GetConnectionString(string nameOrConnectionString) =>
-            ConnectionStringProvider.GetConnectionString(nameOrConnectionString);
+        public string GetConnectionString(string nameOrConnectionString) =>
+            _connectionStringProvider.GetConnectionString(nameOrConnectionString);
 
         /// <summary>
         /// Populate ColumnOptions properties and collections from app config
         /// </summary>
-        internal static ColumnOptions ConfigureColumnOptions(MSSqlServerConfigurationSection config, ColumnOptions columnOptions) =>
-            ColumnOptionsProvider.ConfigureColumnOptions(config, columnOptions);
+        public ColumnOptions ConfigureColumnOptions(MSSqlServerConfigurationSection config, ColumnOptions columnOptions) =>
+            _columnOptionsProvider.ConfigureColumnOptions(config, columnOptions);
     }
 }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/App.config
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/App.config
@@ -9,7 +9,7 @@
   </startup>
 
   <connectionStrings>
-    <add name="NamedConnection" connectionString="Data Source=(LocalDB)\MSSQLLocalDB;Initial Catalog=SerilogTest;Integrated Security=true" providerName="System.Data.SqlClient" />
+    <add name="NamedConnection" connectionString="Data Source=(LocalDB)\MSSQLLocalDB;Initial Catalog=LogTest;Integrated Security=true" providerName="System.Data.SqlClient" />
   </connectionStrings>
   
   <CustomStandardColumnNames>

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Extensions/Microsoft.Extensions.Configuration/ConfigurationExtensionsTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Extensions/Microsoft.Extensions.Configuration/ConfigurationExtensionsTests.cs
@@ -6,14 +6,18 @@ using Xunit;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
+using Xunit.Abstractions;
 
 namespace Serilog.Sinks.MSSqlServer.Tests.Configuration.Extensions.Microsoft.Extensions.Configuration
 {
-    [Collection("LogTest")]
     public class ConfigurationExtensionsTests : DatabaseTestsBase
     {
         private const string ConnectionStringName = "NamedConnection";
         private const string ColumnOptionsSection = "CustomColumnNames";
+
+        public ConfigurationExtensionsTests(ITestOutputHelper output) : base(output)
+        {
+        }
 
         IConfiguration TestConfiguration() =>
             new ConfigurationBuilder()

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Extensions/System.Configuration/ConfigurationExtensionsTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Extensions/System.Configuration/ConfigurationExtensionsTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Linq;
 using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
+using Xunit.Abstractions;
 
 // Because System.Configuration is static and config is loaded automatically,
 // the tests alter the static AppConfigSectionName string value exposed by the
@@ -15,9 +16,12 @@ using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
 
 namespace Serilog.Sinks.MSSqlServer.Tests.Configuration.Extensions.System.Configuration
 {
-    [Collection("LogTest")]
     public class ConfigurationExtensionsTests : DatabaseTestsBase
     {
+        public ConfigurationExtensionsTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public void ConnectionStringByName()
         {

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Implementations/Microsoft.Extensions.Configuration/ApplyMicrosoftExtensionsConfigurationTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Implementations/Microsoft.Extensions.Configuration/ApplyMicrosoftExtensionsConfigurationTests.cs
@@ -5,23 +5,8 @@ using Xunit;
 
 namespace Serilog.Sinks.MSSqlServer.Tests.Configuration.Implementations.Microsoft.Extensions.Configuration
 {
-    [Collection("LogTest")]
     public class ApplyMicrosoftExtensionsConfigurationTests
     {
-        [Fact]
-        public void InitializesSystemConfigurationConnectionStringProvider()
-        {
-            Assert.NotNull(ApplyMicrosoftExtensionsConfiguration.ConnectionStringProvider);
-            Assert.IsType<MicrosoftExtensionsConnectionStringProvider>(ApplyMicrosoftExtensionsConfiguration.ConnectionStringProvider);
-        }
-
-        [Fact]
-        public void InitializesSystemConfigurationColumnOptionsProvider()
-        {
-            Assert.NotNull(ApplyMicrosoftExtensionsConfiguration.ColumnOptionsProvider);
-            Assert.IsType<MicrosoftExtensionsColumnOptionsProvider>(ApplyMicrosoftExtensionsConfiguration.ColumnOptionsProvider);
-        }
-
         [Fact]
         public void GetConfigurationStringCallsAttachedConfigurationStringProvider()
         {
@@ -31,10 +16,10 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Configuration.Implementations.Microsof
             var configurationMock = new Mock<IConfiguration>();
             var connectionStringProviderMock = new Mock<IMicrosoftExtensionsConnectionStringProvider>();
             connectionStringProviderMock.Setup(p => p.GetConnectionString(It.IsAny<string>(), It.IsAny<IConfiguration>())).Returns(expectedResult);
-            ApplyMicrosoftExtensionsConfiguration.ConnectionStringProvider = connectionStringProviderMock.Object;
+            var sut = new ApplyMicrosoftExtensionsConfiguration(connectionStringProviderMock.Object, null);
 
             // Act
-            var result = ApplyMicrosoftExtensionsConfiguration.GetConnectionString(connectionStringName, configurationMock.Object);
+            var result = sut.GetConnectionString(connectionStringName, configurationMock.Object);
 
             // Assert
             connectionStringProviderMock.Verify(p => p.GetConnectionString(connectionStringName, configurationMock.Object), Times.Once);
@@ -51,10 +36,10 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Configuration.Implementations.Microsof
             var columnOptionsProviderMock = new Mock<IMicrosoftExtensionsColumnOptionsProvider>();
             columnOptionsProviderMock.Setup(p => p.ConfigureColumnOptions(It.IsAny<ColumnOptions>(), It.IsAny<IConfigurationSection>()))
                 .Returns(expectedResult);
-            ApplyMicrosoftExtensionsConfiguration.ColumnOptionsProvider = columnOptionsProviderMock.Object;
+            var sut = new ApplyMicrosoftExtensionsConfiguration(null, columnOptionsProviderMock.Object);
 
             // Act
-            var result = ApplyMicrosoftExtensionsConfiguration.ConfigureColumnOptions(inputColumnOptions, configurationSectionMock.Object);
+            var result = sut.ConfigureColumnOptions(inputColumnOptions, configurationSectionMock.Object);
 
             // Assert
             columnOptionsProviderMock.Verify(p => p.ConfigureColumnOptions(inputColumnOptions, configurationSectionMock.Object), Times.Once);

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Implementations/System.Configuration/ApplySystemConfigurationTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Implementations/System.Configuration/ApplySystemConfigurationTests.cs
@@ -5,23 +5,8 @@ using Xunit;
 
 namespace Serilog.Sinks.MSSqlServer.Tests.Configuration.Implementations.System.Configuration
 {
-    [Collection("LogTest")]
     public class ApplySystemConfigurationTests
     {
-        [Fact]
-        public void InitializesSystemConfigurationConnectionStringProvider()
-        {
-            Assert.NotNull(ApplySystemConfiguration.ConnectionStringProvider);
-            Assert.IsType<SystemConfigurationConnectionStringProvider>(ApplySystemConfiguration.ConnectionStringProvider);
-        }
-
-        [Fact]
-        public void InitializesSystemConfigurationColumnOptionsProvider()
-        {
-            Assert.NotNull(ApplySystemConfiguration.ColumnOptionsProvider);
-            Assert.IsType<SystemConfigurationColumnOptionsProvider>(ApplySystemConfiguration.ColumnOptionsProvider);
-        }
-
         [Fact]
         public void GetConfigurationStringCallsAttachedConfigurationStringProvider()
         {
@@ -30,10 +15,10 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Configuration.Implementations.System.C
             const string expectedResult = "TestConnectionString";
             var connectionStringProviderMock = new Mock<ISystemConfigurationConnectionStringProvider>();
             connectionStringProviderMock.Setup(p => p.GetConnectionString(It.IsAny<string>())).Returns(expectedResult);
-            ApplySystemConfiguration.ConnectionStringProvider = connectionStringProviderMock.Object;
+            var sut = new ApplySystemConfiguration(connectionStringProviderMock.Object, null);
 
             // Act
-            var result = ApplySystemConfiguration.GetConnectionString(connectionStringName);
+            var result = sut.GetConnectionString(connectionStringName);
 
             // Assert
             connectionStringProviderMock.Verify(p => p.GetConnectionString(connectionStringName), Times.Once);
@@ -50,10 +35,10 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Configuration.Implementations.System.C
             var columnOptionsProviderMock = new Mock<ISystemConfigurationColumnOptionsProvider>();
             columnOptionsProviderMock.Setup(p => p.ConfigureColumnOptions(It.IsAny<MSSqlServerConfigurationSection>(), It.IsAny<ColumnOptions>()))
                 .Returns(expectedResult);
-            ApplySystemConfiguration.ColumnOptionsProvider = columnOptionsProviderMock.Object;
+            var sut = new ApplySystemConfiguration(null, columnOptionsProviderMock.Object);
 
             // Act
-            var result = ApplySystemConfiguration.ConfigureColumnOptions(inputConfigSection, inputColumnOptions);
+            var result = sut.ConfigureColumnOptions(inputConfigSection, inputColumnOptions);
 
             // Assert
             columnOptionsProviderMock.Verify(p => p.ConfigureColumnOptions(inputConfigSection, inputColumnOptions), Times.Once);

--- a/test/Serilog.Sinks.MSSqlServer.Tests/CustomStandardColumnNamesTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/CustomStandardColumnNamesTests.cs
@@ -7,12 +7,16 @@ using Dapper;
 using Xunit;
 using FluentAssertions;
 using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
+using Xunit.Abstractions;
 
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
-    [Collection("LogTest")]
     public class CustomStandardColumnNamesTests : DatabaseTestsBase
     {
+        public CustomStandardColumnNamesTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public void CustomIdColumn()
         {

--- a/test/Serilog.Sinks.MSSqlServer.Tests/IndexingFeaturesTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/IndexingFeaturesTests.cs
@@ -5,12 +5,16 @@ using Dapper;
 using FluentAssertions;
 using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
-    [Collection("LogTest")]
     public class IndexingFeaturesTests : DatabaseTestsBase
     {
+        public IndexingFeaturesTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public void NonClusteredDefaultIdPrimaryKey()
         {

--- a/test/Serilog.Sinks.MSSqlServer.Tests/LevelAsEnumTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/LevelAsEnumTests.cs
@@ -6,12 +6,16 @@ using FluentAssertions;
 using Serilog.Events;
 using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
-    [Collection("LogTest")]
     public class LevelAsEnumTests : DatabaseTestsBase
     {
+        public LevelAsEnumTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public void CanStoreLevelAsEnum()
         {

--- a/test/Serilog.Sinks.MSSqlServer.Tests/MiscFeaturesTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/MiscFeaturesTests.cs
@@ -7,12 +7,16 @@ using Dapper;
 using FluentAssertions;
 using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
-    [Collection("LogTest")]
     public class MiscFeaturesTests : DatabaseTestsBase
     {
+        public MiscFeaturesTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public void LogEventExcludeAdditionalProperties()
         {

--- a/test/Serilog.Sinks.MSSqlServer.Tests/PropertiesColumnFilteringTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/PropertiesColumnFilteringTests.cs
@@ -1,15 +1,18 @@
 ﻿using Dapper;
 using FluentAssertions;
 using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
-using System;
 using System.Data.SqlClient;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
-    [Collection("LogTest")]
     public class PropertiesColumnFilteringTests : DatabaseTestsBase
     {
+        public PropertiesColumnFilteringTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Fact]
         public void FilteredProperties()
         {

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/ColumnOptions/TimeStampColumnOptionsTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/ColumnOptions/TimeStampColumnOptionsTests.cs
@@ -4,7 +4,6 @@ using Xunit;
 
 namespace Serilog.Sinks.MSSqlServer.Tests.Sinks.MSSqlServer.ColumnOptions
 {
-    [Collection("LogTest")]
     public class TimeStampColumnOptionsTests
     {
         [Trait("Bugfix", "#187")]

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/MSSqlServerSinkTraitsTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/MSSqlServerSinkTraitsTests.cs
@@ -13,7 +13,6 @@ using Xunit;
 
 namespace Serilog.Sinks.MSSqlServer.Tests.Sinks.MSSqlServer
 {
-    [Collection("LogTest")]
     public class MSSqlServerSinkTraitsTests
     {
         private readonly string _connectionString = "connectionString";

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlCreateTableWriterTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlCreateTableWriterTests.cs
@@ -4,7 +4,6 @@ using Xunit;
 
 namespace Serilog.Sinks.MSSqlServer.Tests.Sinks.MSSqlServer.Platform
 {
-    [Collection("LogTest")]
     public class SqlCreateTableWriterTests
     {
         private readonly SqlCreateTableWriter _sut;

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlTableCreatorTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlTableCreatorTests.cs
@@ -6,16 +6,16 @@ using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
 using System.Data;
 using System.Data.SqlClient;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Serilog.Sinks.MSSqlServer.Tests.Sinks.MSSqlServer.Platform
 {
-    [Collection("LogTest")]
     public class SqlTableCreatorTests : DatabaseTestsBase
     {
         private readonly Mock<ISqlCreateTableWriter> _sqlWriterMock;
         private readonly SqlTableCreator _sut;
 
-        public SqlTableCreatorTests()
+        public SqlTableCreatorTests(ITestOutputHelper output) : base(output)
         {
             _sqlWriterMock = new Mock<ISqlCreateTableWriter>();
             _sut = new SqlTableCreator(_sqlWriterMock.Object);

--- a/test/Serilog.Sinks.MSSqlServer.Tests/SqlTypesTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/SqlTypesTests.cs
@@ -4,12 +4,16 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Data;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
-    [Collection("LogTest")]
     public class SqlTypesTests : DatabaseTestsBase
     {
+        public SqlTypesTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         // Since the point of these tests are to validate we can write to
         // specific underlying SQL Server column data types, we use audit
         // logging so exceptions from logevent writes do not fail silently.

--- a/test/Serilog.Sinks.MSSqlServer.Tests/TestUtils/DatabaseTestsBase.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/TestUtils/DatabaseTestsBase.cs
@@ -1,10 +1,20 @@
 ﻿using System;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace Serilog.Sinks.MSSqlServer.Tests.TestUtils
 {
+    [Collection("LogTest")]
     public abstract class DatabaseTestsBase : IDisposable
     {
+        private readonly ITestOutputHelper _output;
         private bool _disposedValue;
+
+        public DatabaseTestsBase(ITestOutputHelper output)
+        {
+            _output = output;
+            Serilog.Debugging.SelfLog.Enable(_output.WriteLine);
+        }
 
         protected virtual void Dispose(bool disposing)
         {

--- a/test/Serilog.Sinks.MSSqlServer.Tests/TimeStampTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/TimeStampTests.cs
@@ -5,12 +5,16 @@ using Dapper;
 using FluentAssertions;
 using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
-    [Collection("LogTest")]
     public class TimeStampTests : DatabaseTestsBase
     {
+        public TimeStampTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
         [Trait("Bugfix", "#187")]
         [Fact]
         public void CanCreateDatabaseWithDateTimeByDefault()

--- a/test/Serilog.Sinks.MSSqlServer.Tests/TriggersOnLogTableTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/TriggersOnLogTableTests.cs
@@ -4,13 +4,17 @@ using Dapper;
 using FluentAssertions;
 using Serilog.Sinks.MSSqlServer.Tests.TestUtils;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Serilog.Sinks.MSSqlServer.Tests
 {
-    [Collection("LogTest")]
     public class TriggersOnLogTableTests : DatabaseTestsBase
     {
         private bool _disposedValue;
+
+        public TriggersOnLogTableTests(ITestOutputHelper output) : base(output)
+        {
+        }
 
         [Fact]
         public void TestTriggerOnLogTableFire()


### PR DESCRIPTION
* Fixed unit test parallel execution: made classes ApplySystemConfiguration and ApplyMicrosoftExtensionsConfiguration non static
* Exclude all non-database unit tests from test collection allowing them to run in parallel to DB tests.
* Activated SelfLog to xUnit ITestOutputHelper for all database tests.
* Fixed long duration of test Extensions.System.Configuration.ConfigurationExtensionsTests.ConnectionStringByName due to a wrong database name in App.config.