### PR TITLE
AppVeyor build changes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: '{build}'
 skip_tags: true
-image: Visual Studio 2017
+image: Visual Studio 2019
 configuration: Release
 install:
   - ps: mkdir -Force ".\build\" | Out-Null
@@ -9,13 +9,6 @@ build_script:
 test: off
 artifacts:
 - path: artifacts/Serilog.*.nupkg
-only_commits:
-  files:
-    - serilog-sinks-mssqlserver.sln
-    - src/Serilog.Sinks.MSSqlServer/
-    - Build.ps1
-    - assets/
-    - test/Serilog.Sinks.MSSqlServer.Tests/
 deploy:
 - provider: NuGet
   api_key:


### PR DESCRIPTION
* Use Visual Studio 2019 image.
* Build on every commit  (no filter for dirs and files).