### PR TITLE
Use Microsoft.Data.SqlClient for all platforms except net452

### DIFF
--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -55,7 +55,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
     <Compile Include="Configuration\Extensions\Microsoft.Extensions.Configuration\**\*.cs" />
@@ -65,7 +65,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' Or '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
     <Compile Include="Configuration\Extensions\Hybrid\**\*.cs" />
@@ -76,7 +76,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' Or '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.3" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticator.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+#if NET452
 using System.Data.SqlClient;
+#else
+using Microsoft.Data.SqlClient;
+#endif
 using Microsoft.Azure.Services.AppAuthentication;
 
 namespace Serilog.Sinks.MSSqlServer.Sinks.MSSqlServer.Platform

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorStub.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorStub.cs
@@ -1,5 +1,10 @@
 ﻿using System;
+#if NET452
 using System.Data.SqlClient;
+#else
+using Microsoft.Data.SqlClient;
+#endif
+
 using System.Diagnostics.CodeAnalysis;
 
 // This is an empty stub implementaion of IAzureManagedServiceAuthenticator for the target frameworks

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/IAzureManagedServiceAuthenticator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/IAzureManagedServiceAuthenticator.cs
@@ -1,4 +1,8 @@
-﻿using System.Data.SqlClient;
+﻿#if NET452
+using System.Data.SqlClient;
+#else
+using Microsoft.Data.SqlClient;
+#endif
 
 namespace Serilog.Sinks.MSSqlServer.Sinks.MSSqlServer.Platform
 {

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/ISqlConnectionFactory.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/ISqlConnectionFactory.cs
@@ -1,4 +1,8 @@
-﻿using System.Data.SqlClient;
+﻿#if NET452
+using System.Data.SqlClient;
+#else
+using Microsoft.Data.SqlClient;
+#endif
 
 namespace Serilog.Sinks.MSSqlServer.Sinks.MSSqlServer.Platform
 {

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlBulkBatchWriter.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlBulkBatchWriter.cs
@@ -1,7 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+#if NET452
 using System.Data.SqlClient;
+#else
+using Microsoft.Data.SqlClient;
+#endif
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlConnectionFactory.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlConnectionFactory.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+#if NET452
 using System.Data.SqlClient;
+#else
+using Microsoft.Data.SqlClient;
+#endif
 
 namespace Serilog.Sinks.MSSqlServer.Sinks.MSSqlServer.Platform
 {

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlLogEventWriter.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlLogEventWriter.cs
@@ -1,6 +1,10 @@
 ﻿using System;
 using System.Data;
+#if NET452
 using System.Data.SqlClient;
+#else
+using Microsoft.Data.SqlClient;
+#endif
 using System.Text;
 using Serilog.Debugging;
 using Serilog.Events;

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlTableCreator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlTableCreator.cs
@@ -1,6 +1,10 @@
 ﻿using System;
 using System.Data;
+#if NET452
 using System.Data.SqlClient;
+#else
+using Microsoft.Data.SqlClient;
+#endif
 using Serilog.Debugging;
 using Serilog.Sinks.MSSqlServer.Sinks.MSSqlServer.Platform;
 

--- a/src/Serilog.Sinks.MSSqlServer/packages.config
+++ b/src/Serilog.Sinks.MSSqlServer/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="Serilog" version="2.5.0" targetFramework="net452" />
   <package id="Serilog.Sinks.PeriodicBatching" version="2.1.1" targetFramework="net452" />
+  <package id="System.Data.SqlClient" Version="4.6.0" targetFramework="net452" />
 </packages>

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorTests.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+#if NET452
 using System.Data.SqlClient;
+#else
+using Microsoft.Data.SqlClient;
+#endif
 using Microsoft.Azure.Services.AppAuthentication;
 using Serilog.Sinks.MSSqlServer.Sinks.MSSqlServer.Platform;
 using Serilog.Sinks.MSSqlServer.Tests.TestUtils;

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlTableCreatorTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlTableCreatorTests.cs
@@ -1,5 +1,9 @@
 ﻿using System.Data;
+#if NET452
 using System.Data.SqlClient;
+#else
+using Microsoft.Data.SqlClient;
+#endif
 using Dapper;
 using FluentAssertions;
 using Moq;


### PR DESCRIPTION
Replaced System.Data.SqlClient with Microsoft.Data.SqlClient for all platforms except net452 (Microsoft.Data.SqlClient does not support net452). 

Only the references and the namespaces needed to be changed in order to accommodate this. However, in order to support both packages in the same code base (again, due to net452), I had to add #if directives around the using statements to use the correct SqlClient library.

Resolves #208 