### PR TITLE
Fixed code analysis warning

### DIFF
--- a/test/Serilog.Sinks.MSSqlServer.Tests/Serilog.Sinks.MSSqlServer.Tests.csproj
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Serilog.Sinks.MSSqlServer.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.0;netcoreapp2.2</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Serilog.Sinks.MSSqlServer.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/Serilog.Sinks.MSSqlServer.Tests/TestUtils/DatabaseTestsBase.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/TestUtils/DatabaseTestsBase.cs
@@ -109,7 +109,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.TestUtils
             {
                 var logEvents = conn.Query<CustomStandardLogColumns>($"SELECT CustomMessage FROM {DatabaseFixture.LogTableName}");
 
-                logEvents.Should().Contain(e => e.CustomMessage.Contains(expectedMessage));
+                logEvents.Should().Contain(e => e.CustomMessage == expectedMessage);
             }
         }
 


### PR DESCRIPTION
 Fixed code analysis warning in tests base class and set TreatWarningsAsErrors in test project (same as  in main project).