### PR TITLE
Add support for DateTime2 DataType in TimeStamp column.

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ var columnOptions = new ColumnOptions();
 columnOptions.TimeStamp.DataType = SqlDbType.DateTime2;
 ```
 
-Please be aware that you have to configure the sink for `datetimeoffset` if the used logging database table has a `TimeStamp` column of type `datetimeoffset`. If the underlying database uses `datetime2` for the `TimeStamp` column, the sink must be configured to use `datetime2`. On the other hand you must not configure for `datetimeoffset` if the `TimeStamp` column is of type `datetime`. Failing to configure the data type accordingly can result in log table entries with wrong timezone offsets or no log entries being created at all due to exceptions during logging.
+Please be aware that you have to configure the sink for `datetimeoffset` if the used logging database table has a `TimeStamp` column of type `datetimeoffset`. If the underlying database uses `datetime2` for the `TimeStamp` column, the sink must be configured to use `datetime2`. On the other hand you must not configure for `datetimeoffset` if the `TimeStamp` column is of type `datetime` or `datetime2`. Failing to configure the data type accordingly can result in log table entries with wrong timezone offsets or no log entries being created at all due to exceptions during logging.
 
 While TimeStamp may appear to be a good candidate as a clustered primary key, even relatively low-volume logging can emit identical timestamps forcing SQL Server to add a "uniqueifier" value behind the scenes (effectively an auto-incrementing identity-like integer). For frequent timestamp range-searching and sorting, a non-clustered index is better.
 

--- a/README.md
+++ b/README.md
@@ -436,14 +436,19 @@ This column stores the event level (Error, Information, etc.). For backwards-com
 
 ### TimeStamp
 
-This column stores the time the log event was sent to Serilog as a SQL `datetime` (default) or `datetimeoffset` type. If `datetimeoffset` should be used, this can be configured as follows.
+This column stores the time the log event was sent to Serilog as a SQL `datetime` (default), `datetime2` or `datetimeoffset` type. If `datetime2` or `datetimeoffset` should be used, this can be configured as follows.
 
 ```csharp
 var columnOptions = new ColumnOptions();
 columnOptions.TimeStamp.DataType = SqlDbType.DateTimeOffset;
 ```
 
-Please be aware that you have to configure the sink for `datetimeoffset` if the used logging database table has a `TimeStamp` column of type `datetimeoffset`. On the other hand you must not configure for `datetimeoffset` if the `TimeStamp` column is of type `datetime`. Failing to configure the data type accordingly can result in log table entries with wrong timezone offsets or no log entries being created at all due to exceptions during logging.
+```csharp
+var columnOptions = new ColumnOptions();
+columnOptions.TimeStamp.DataType = SqlDbType.DateTime2;
+```
+
+Please be aware that you have to configure the sink for `datetimeoffset` if the used logging database table has a `TimeStamp` column of type `datetimeoffset`. If the underlying database uses `datetime2` for the `TimeStamp` column, the sink must be configured to use `datetime2`. On the other hand you must not configure for `datetimeoffset` if the `TimeStamp` column is of type `datetime`. Failing to configure the data type accordingly can result in log table entries with wrong timezone offsets or no log entries being created at all due to exceptions during logging.
 
 While TimeStamp may appear to be a good candidate as a clustered primary key, even relatively low-volume logging can emit identical timestamps forcing SQL Server to add a "uniqueifier" value behind the scenes (effectively an auto-incrementing identity-like integer). For frequent timestamp range-searching and sorting, a non-clustered index is better.
 

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/TimeStampColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/TimeStampColumnOptions.cs
@@ -20,15 +20,15 @@ namespace Serilog.Sinks.MSSqlServer
             }
 
             /// <summary>
-            /// The TimeStamp column only supports the DateTime and DateTimeOffset data types.
+            /// The TimeStamp column only supports the DateTime, DateTime2 and DateTimeOffset data types.
             /// </summary>
             public new SqlDbType DataType
             {
                 get => base.DataType;
                 set
                 {
-                    if (value != SqlDbType.DateTime && value != SqlDbType.DateTimeOffset)
-                        throw new ArgumentException("The Standard Column \"TimeStamp\" only supports the DateTime and DateTimeOffset formats.");
+                    if (value != SqlDbType.DateTime && value != SqlDbType.DateTimeOffset && value != SqlDbType.DateTime2)
+                        throw new ArgumentException("The Standard Column \"TimeStamp\" only supports the DateTime, DateTime2 and DateTimeOffset formats.");
                     base.DataType = value;
                 }
             }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/JsonLogEventFormatter.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/JsonLogEventFormatter.cs
@@ -124,7 +124,7 @@ namespace Serilog.Sinks.MSSqlServer.Output
             output.Write(precedingDelimiter);
             precedingDelimiter = _commaDelimiter;
             var colData = WritePropertyName(logEvent, output, StandardColumn.TimeStamp);
-            var value = _columnOptions.TimeStamp.DataType == SqlDbType.DateTime
+            var value = (_columnOptions.TimeStamp.DataType == SqlDbType.DateTime || _columnOptions.TimeStamp.DataType == SqlDbType.DateTime2)
                 ? ((DateTime)colData.Value).ToString("o", CultureInfo.InvariantCulture)
                 : ((DateTimeOffset)colData.Value).ToString("o", CultureInfo.InvariantCulture);
             JsonValueFormatter.WriteQuotedJsonString(value, output);

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/ColumnOptions/TimeStampColumnOptionsTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/ColumnOptions/TimeStampColumnOptionsTests.cs
@@ -40,5 +40,16 @@ namespace Serilog.Sinks.MSSqlServer.Tests.ColumnOptions
             // Act and assert - should throw
             Assert.Throws<ArgumentException>(() => options.TimeStamp.DataType = SqlDbType.NVarChar);
         }
+
+        [Trait("Feature", "#300")]
+        [Fact]
+        public void CanSetDataTypeDateTime2()
+        {
+            // Arrange
+            var options = new Serilog.Sinks.MSSqlServer.ColumnOptions();
+
+            // Act - should not throw
+            options.TimeStamp.DataType = SqlDbType.DateTime2;
+        }
     }
 }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/JsonLogEventFormatterTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/JsonLogEventFormatterTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.IO;
@@ -77,6 +77,27 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Output
             // Arrange
             const string expectedResult = "{\"TimeStamp\":\"2020-03-27T14:17:00.0000000\",\"Level\":\"Information\",\"Message\":\"\",\"MessageTemplate\":\"Test message template\"}";
             var testLogEvent = CreateTestLogEvent(new DateTimeOffset(2020, 3, 27, 14, 17, 0, TimeSpan.Zero));
+
+            // Act
+            string renderResult;
+            using (var outputWriter = new StringWriter())
+            {
+                _sut.Format(testLogEvent, outputWriter);
+                renderResult = outputWriter.ToString();
+            }
+
+            // Assert
+            Assert.Equal(expectedResult, renderResult);
+        }
+
+        [Fact]
+        [Trait("Feature", "#300")]
+        public void FormatTimeStampColumnTypeDateTime2RendersCorrectTimeStamp()
+        {
+            // Arrange
+            const string expectedResult = "{\"TimeStamp\":\"2020-07-01T09:41:10.1230000\",\"Level\":\"Information\",\"Message\":\"\",\"MessageTemplate\":\"Test message template\"}";
+            _testColumnOptions.TimeStamp.DataType = SqlDbType.DateTime2;
+            var testLogEvent = CreateTestLogEvent(new DateTimeOffset(2020, 7, 1, 9, 41, 10, 123, TimeSpan.Zero));
 
             // Act
             string renderResult;


### PR DESCRIPTION
This PR adds DateTime2 as a supported underlying DataType for the TimeStamp column.

Fix #300.