### PR TITLE
Added support to pass a connection string to AzureServiceTokenProvider

### DIFF
--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/Microsoft.Extensions.Configuration/MicrosoftExtensionsSinkOptionsProvider.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/Microsoft.Extensions.Configuration/MicrosoftExtensionsSinkOptionsProvider.cs
@@ -38,6 +38,7 @@ namespace Serilog.Sinks.MSSqlServer.Configuration
         {
             SetProperty.IfNotNull<bool>(config["useAzureManagedIdentity"], val => sinkOptions.UseAzureManagedIdentity = val);
             SetProperty.IfNotNull<string>(config["azureServiceTokenProviderResource"], val => sinkOptions.AzureServiceTokenProviderResource = val);
+            SetProperty.IfNotNull<string>(config["azureServiceTokenProviderConnectionString"], val => sinkOptions.AzureServiceTokenProviderConnectionString = val);
         }
     }
 }

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/MSSqlServerConfigurationSection.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/MSSqlServerConfigurationSection.cs
@@ -191,6 +191,12 @@ namespace Serilog.Configuration
         {
             get => (ValueConfigElement)base[nameof(AzureServiceTokenProviderResource)];
         }
+
+        [ConfigurationProperty(nameof(AzureServiceTokenProviderConnectionString))]
+        public ValueConfigElement AzureServiceTokenProviderConnectionString
+        {
+            get => (ValueConfigElement)base[nameof(AzureServiceTokenProviderConnectionString)];
+        }
     }
 }
 

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/SystemConfigurationSinkOptionsProvider.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/SystemConfigurationSinkOptionsProvider.cs
@@ -37,6 +37,8 @@ namespace Serilog.Sinks.MSSqlServer.Configuration
                 value => sinkOptions.UseAzureManagedIdentity = value);
             SetProperty.IfProvided<string>(config.AzureServiceTokenProviderResource, nameof(config.AzureServiceTokenProviderResource.Value),
                 value => sinkOptions.AzureServiceTokenProviderResource = value);
+            SetProperty.IfProvided<string>(config.AzureServiceTokenProviderConnectionString, nameof(config.AzureServiceTokenProviderConnectionString.Value),
+               value => sinkOptions.AzureServiceTokenProviderConnectionString = value);
         }
     }
 }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Dependencies/SinkDependenciesFactory.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Dependencies/SinkDependenciesFactory.cs
@@ -22,7 +22,8 @@ namespace Serilog.Sinks.MSSqlServer.Dependencies
                     sinkOptions?.UseAzureManagedIdentity ?? default,
                     new AzureManagedServiceAuthenticator(
                         sinkOptions?.UseAzureManagedIdentity ?? default,
-                        sinkOptions.AzureServiceTokenProviderResource));
+                        sinkOptions.AzureServiceTokenProviderResource,
+                        sinkOptions.AzureServiceTokenProviderConnectionString));
             var logEventDataGenerator =
                 new LogEventDataGenerator(columnOptions,
                     new StandardColumnDataGenerator(columnOptions, formatProvider,

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSinkOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSinkOptions.cs
@@ -71,5 +71,11 @@ namespace Serilog.Sinks.MSSqlServer
         /// Azure service token provider to be used for Azure Managed Identities
         /// </summary>
         public string AzureServiceTokenProviderResource { get; set; }
+
+        /// <summary>
+        /// Azure auth connection string to be used for Azure Managed Identities
+        /// <see href="https://docs.microsoft.com/en-us/dotnet/api/overview/azure/service-to-service-authentication#connection-string-support"/> 
+        /// </summary>
+        public string AzureServiceTokenProviderConnectionString { get; set; }
     }
 }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticator.cs
@@ -10,7 +10,7 @@ namespace Serilog.Sinks.MSSqlServer.Platform
         private readonly string _azureServiceTokenProviderResource;
         private readonly AzureServiceTokenProvider _azureServiceTokenProvider;
 
-        public AzureManagedServiceAuthenticator(bool useAzureManagedIdentity, string azureServiceTokenProviderResource)
+        public AzureManagedServiceAuthenticator(bool useAzureManagedIdentity, string azureServiceTokenProviderResource, string azureServiceTokenProviderConnectionString)
         {
             if (useAzureManagedIdentity && string.IsNullOrWhiteSpace(azureServiceTokenProviderResource))
             {
@@ -19,7 +19,7 @@ namespace Serilog.Sinks.MSSqlServer.Platform
 
             _useAzureManagedIdentity = useAzureManagedIdentity;
             _azureServiceTokenProviderResource = azureServiceTokenProviderResource;
-            _azureServiceTokenProvider = new AzureServiceTokenProvider();
+            _azureServiceTokenProvider = new AzureServiceTokenProvider(azureServiceTokenProviderConnectionString);
         }
 
         public Task<string> GetAuthenticationToken()

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorStub.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorStub.cs
@@ -12,7 +12,7 @@ namespace Serilog.Sinks.MSSqlServer.Platform
         private readonly bool _useAzureManagedIdentity;
         private readonly string _azureServiceTokenProviderResource;
 
-        public AzureManagedServiceAuthenticator(bool useAzureManagedIdentity, string azureServiceTokenProviderResource)
+        public AzureManagedServiceAuthenticator(bool useAzureManagedIdentity, string azureServiceTokenProviderResource, string _)
         {
             if (useAzureManagedIdentity)
             {

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorStubTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorStubTests.cs
@@ -11,14 +11,14 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
         [Fact]
         public void InitializeDoesNotThrowsIfUseAzureManagedIdentityIsFalse()
         {
-            _ = new AzureManagedServiceAuthenticator(false, "TestAccessToken");
+            _ = new AzureManagedServiceAuthenticator(false, "TestAccessToken", null);
         }
 
         [Fact]
         public void InitializeThrowsIfUseAzureManagedIdentityIsTrue()
         {
             // Throws because operation is not supported on the target framework that uses stub implementation
-            Assert.Throws<InvalidOperationException>(() => new AzureManagedServiceAuthenticator(true, "TestAccessToken"));
+            Assert.Throws<InvalidOperationException>(() => new AzureManagedServiceAuthenticator(true, "TestAccessToken", null));
         }
     }
 }

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorTests.cs
@@ -13,26 +13,26 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
         [Fact]
         public void InitializeThrowsIfUseAzureManagedIdentityIsTrueAndAuthenticatorIsNull()
         {
-            Assert.Throws<ArgumentNullException>(() => new AzureManagedServiceAuthenticator(true, null));
+            Assert.Throws<ArgumentNullException>(() => new AzureManagedServiceAuthenticator(true, null, null));
         }
 
         [Fact]
         public void InitializeThrowsIfUseAzureManagedIdentityIsTrueAndAuthenticatorIsEmpty()
         {
-            Assert.Throws<ArgumentNullException>(() => new AzureManagedServiceAuthenticator(true, string.Empty));
+            Assert.Throws<ArgumentNullException>(() => new AzureManagedServiceAuthenticator(true, string.Empty, null));
         }
 
         [Fact]
         public void InitializeThrowsIfUseAzureManagedIdentityIsTrueAndAuthenticatorIsWhitespace()
         {
-            Assert.Throws<ArgumentNullException>(() => new AzureManagedServiceAuthenticator(true, "    "));
+            Assert.Throws<ArgumentNullException>(() => new AzureManagedServiceAuthenticator(true, "    ", null));
         }
 
         [Fact]
         public async Task GetAuthenticationTokenReturnsNullIfUseAzureManagedIdentityIsFalse()
         {
             // Arrange
-            var sut = new AzureManagedServiceAuthenticator(false, null);
+            var sut = new AzureManagedServiceAuthenticator(false, null, null);
 
             // Act
             var result = await sut.GetAuthenticationToken().ConfigureAwait(false);
@@ -45,7 +45,7 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
         public async Task GetAuthenticationTokenThrowsIfUseAzureManagedIdentityIsTrueAndTokenInvalid()
         {
             // Arrange
-            var sut = new AzureManagedServiceAuthenticator(true, "TestAccessToken");
+            var sut = new AzureManagedServiceAuthenticator(true, "TestAccessToken", null);
 
             // Act + assert
             await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => sut.GetAuthenticationToken()).ConfigureAwait(false);


### PR DESCRIPTION
Added support to pass a connection string to AzureServiceTokenProvider which can be used for "User Managed Identities"
Default value is null (which is used by the default constructor of AzureServiceProvider, which was used before)
The AzureServiceProvider uses this connectionstring if it is specified as an Environment Variable by default, but it might be helpful to be able to pass it as a parameter instead, in some scenarios.

Should fix #302 

@ckadluba do you have any ideas on (unit) tests for this? I looked in the AzureManagedServiceAuthenticatorTests, should I add some new tests there with some different combinations of the connection string? They will all throw an exception since the token will be invalid