### PR TITLE
Add configurable tenant ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,24 @@ See [Azure AD-managed identities for Azure resources documentation](https://docs
 
 ### AzureServiceTokenProviderResource
 
-Specifies the token provider resource to be used for aquiring an authentication token when using Azure Managed Identities for authenticating with an Azure SQL server. This setting is only used if `UseAzureManagedIdentity` is set to `true`.
+Specifies the token provider resource to be used for aquiring an authentication token when using Azure Managed Identities for authenticating with an Azure SQL server. This setting is only used if `UseAzureManagedIdentity` is set to `true`. For Azure SQL databases this value will always be `https://database.windows.net/`.
+
+### AzureTenantId
+
+Specifies the tenant ID of the the tenant the Azure SQL database exists in. This only needs to be set if the user authenticating against the database is in a different tenant to the database. This will most likely be the case when you are debugging locally and authenticating as yourself rather than the app to be deployed to.
+
+```
+ .WriteTo.MSSqlServer(
+	Environment.GetEnvironmentVariable("LogConnection"),
+	sinkOptions: new MSSqlServerSinkOptions()
+	{
+		TableName = "_Log",
+		UseAzureManagedIdentity = true,
+		AzureServiceTokenProviderResource = "https://database.windows.net/",
+		AzureTenantId = Environment.GetEnvironmentVariable("AZURE_TENANT_ID")
+	}
+```
+
 
 ## ColumnOptions Object
 

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/Microsoft.Extensions.Configuration/MicrosoftExtensionsSinkOptionsProvider.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/Microsoft.Extensions.Configuration/MicrosoftExtensionsSinkOptionsProvider.cs
@@ -38,6 +38,7 @@ namespace Serilog.Sinks.MSSqlServer.Configuration
         {
             SetProperty.IfNotNull<bool>(config["useAzureManagedIdentity"], val => sinkOptions.UseAzureManagedIdentity = val);
             SetProperty.IfNotNull<string>(config["azureServiceTokenProviderResource"], val => sinkOptions.AzureServiceTokenProviderResource = val);
+            SetProperty.IfNotNull<string>(config["azureTenantId"], val => sinkOptions.AzureTenantId = val);
         }
     }
 }

--- a/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/MSSqlServerConfigurationSection.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Configuration/Implementations/System.Configuration/MSSqlServerConfigurationSection.cs
@@ -191,6 +191,13 @@ namespace Serilog.Configuration
         {
             get => (ValueConfigElement)base[nameof(AzureServiceTokenProviderResource)];
         }
+
+
+        [ConfigurationProperty(nameof(AzureTenantId))]
+        public ValueConfigElement AzureTenantId
+        {
+            get => (ValueConfigElement)base[nameof(AzureTenantId)];
+        }
     }
 }
 

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Dependencies/SinkDependenciesFactory.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Dependencies/SinkDependenciesFactory.cs
@@ -22,7 +22,8 @@ namespace Serilog.Sinks.MSSqlServer.Dependencies
                     sinkOptions?.UseAzureManagedIdentity ?? default,
                     new AzureManagedServiceAuthenticator(
                         sinkOptions?.UseAzureManagedIdentity ?? default,
-                        sinkOptions.AzureServiceTokenProviderResource));
+                        sinkOptions.AzureServiceTokenProviderResource,
+                        sinkOptions.AzureTenantId));
             var logEventDataGenerator =
                 new LogEventDataGenerator(columnOptions,
                     new StandardColumnDataGenerator(columnOptions, formatProvider,

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSinkOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/MSSqlServerSinkOptions.cs
@@ -71,5 +71,10 @@ namespace Serilog.Sinks.MSSqlServer
         /// Azure service token provider to be used for Azure Managed Identities
         /// </summary>
         public string AzureServiceTokenProviderResource { get; set; }
+
+        /// <summary>
+        /// ID of the tenant where the Azure resource exists
+        /// </summary>
+        public string AzureTenantId { get; set; }
     }
 }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticator.cs
@@ -8,9 +8,10 @@ namespace Serilog.Sinks.MSSqlServer.Platform
     {
         private readonly bool _useAzureManagedIdentity;
         private readonly string _azureServiceTokenProviderResource;
+        private readonly string _tenantId;
         private readonly AzureServiceTokenProvider _azureServiceTokenProvider;
 
-        public AzureManagedServiceAuthenticator(bool useAzureManagedIdentity, string azureServiceTokenProviderResource)
+        public AzureManagedServiceAuthenticator(bool useAzureManagedIdentity, string azureServiceTokenProviderResource, string tenantId = null)
         {
             if (useAzureManagedIdentity && string.IsNullOrWhiteSpace(azureServiceTokenProviderResource))
             {
@@ -19,6 +20,7 @@ namespace Serilog.Sinks.MSSqlServer.Platform
 
             _useAzureManagedIdentity = useAzureManagedIdentity;
             _azureServiceTokenProviderResource = azureServiceTokenProviderResource;
+            _tenantId = tenantId;
             _azureServiceTokenProvider = new AzureServiceTokenProvider();
         }
 
@@ -29,7 +31,7 @@ namespace Serilog.Sinks.MSSqlServer.Platform
                 return Task.FromResult((string)null);
             }
 
-            return _azureServiceTokenProvider.GetAccessTokenAsync(_azureServiceTokenProviderResource);
+            return _azureServiceTokenProvider.GetAccessTokenAsync(_azureServiceTokenProviderResource, _tenantId);
         }
     }
 }

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorStub.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorStub.cs
@@ -11,8 +11,9 @@ namespace Serilog.Sinks.MSSqlServer.Platform
     {
         private readonly bool _useAzureManagedIdentity;
         private readonly string _azureServiceTokenProviderResource;
+        private readonly string _tenantId;
 
-        public AzureManagedServiceAuthenticator(bool useAzureManagedIdentity, string azureServiceTokenProviderResource)
+        public AzureManagedServiceAuthenticator(bool useAzureManagedIdentity, string azureServiceTokenProviderResource, string tenantId = null)
         {
             if (useAzureManagedIdentity)
             {
@@ -22,6 +23,7 @@ namespace Serilog.Sinks.MSSqlServer.Platform
 
             _useAzureManagedIdentity = useAzureManagedIdentity;
             _azureServiceTokenProviderResource = azureServiceTokenProviderResource;
+            _tenantId = tenantId;
         }
 
         public Task<string> GetAuthenticationToken() => Task.FromResult((string)null);

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Implementations/Microsoft.Extensions.Configuration/MicrosoftExtensionsSinkOptionsProviderTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Configuration/Implementations/Microsoft.Extensions.Configuration/MicrosoftExtensionsSinkOptionsProviderTests.cs
@@ -150,5 +150,20 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Configuration.Implementations.Microsof
             // Assert
             Assert.Equal(azureServiceTokenProviderResource, result.AzureServiceTokenProviderResource);
         }
+
+        [Fact]
+        public void ConfigureSinkOptionsSetsAzureTenantId()
+        {
+            // Arrange
+            const string azureTenantId = "00000000-0000-0000-0000-000000000000";
+            _configurationSectionMock.Setup(s => s["azureTenantId"]).Returns(azureTenantId);
+            var sut = new MicrosoftExtensionsSinkOptionsProvider();
+
+            // Act
+            var result = sut.ConfigureSinkOptions(new MSSqlServerSinkOptions(), _configurationSectionMock.Object);
+
+            // Assert
+            Assert.Equal(azureTenantId, result.AzureTenantId);
+        }
     }
 }


### PR DESCRIPTION
When authenticating against a SQL database using MSI if the the user exists in a different tenant to the resource then authentication will fail as `GetAccessTokenAsync` will assume the resource is in the same tenant as the user.

`GetAccessTokenAsync` takes an optional `tenantId` parameter that I have added to the sink options to allow it to be passed through.

On a related note I think `azureServiceTokenProviderResource` can only ever be https://database.windows.net/ given this sink will only ever need to authenticate against a SQL resource so this could probably be stored as a constant and removed from the sink options.

```
            // Initialize serilog logger
            Log.Logger = new LoggerConfiguration()
                 .WriteTo.Console(Serilog.Events.LogEventLevel.Debug)
                 .WriteTo.MSSqlServer(
                    Environment.GetEnvironmentVariable("LogConnection"),
                    sinkOptions: new MSSqlServerSinkOptions()
                    {
                        TableName = "_Log",
                        UseAzureManagedIdentity = true,
                        AzureServiceTokenProviderResource = "https://database.windows.net/",
                        AzureTenantId = Environment.GetEnvironmentVariable("AZURE_TENANT_ID")
                    },
                    columnOptions: columnOptions,
                    restrictedToMinimumLevel: Serilog.Events.LogEventLevel.Debug
                    )
                 .MinimumLevel.Debug()
                 .Enrich.FromLogContext()
                 .CreateLogger();
```