### PR TITLE
Updated EOL .NET framework and README correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ Because of the way external configuration has been implemented in various .NET f
 | Your Framework | TFM | Project Types | External Configuration |
 | --- | --- | --- |  --- |
 | .NET Framework 4.5.2 | `net452` | app or library | _System.Configuration_ |
-| .NET Framework 4.6.1+ | `net461` | app or library | _System.Configuration_ |
-| .NET Framework 4.6.1+ | `net461` | app or library | _Microsoft.Extensions.Configuration_ |
+| .NET Framework 4.6.2+ | `net462` | app or library | _System.Configuration_ |
+| .NET Framework 4.6.2+ | `net462` | app or library | _Microsoft.Extensions.Configuration_ |
 | .NET Standard 2.0 | `netstandard2.0` | library only | _Microsoft.Extensions.Configuration_ |
 | .NET Core 3.1+ | `netcoreapp3.1` | app or library | _System.Configuration_ |
 | .NET Core 3.1+ | `netcoreapp3.1` | app or library | _Microsoft.Extensions.Configuration_ |
 
-Support for .NET Framework 4.5.2 is tied to the Windows 8.1 lifecycle with support scheduled to end in January 2023.
+Support for .NET Framework 4.5.2 is tied to the Windows 8.1 lifecycle with support scheduled to end in April 2022 (https://devblogs.microsoft.com/dotnet/net-framework-4-5-2-4-6-4-6-1-will-reach-end-of-support-on-april-26-2022/).
 
 Although it's possible to use both XML and _M.E.C_ configuration with certain frameworks, this is not supported, unintended consequences are possible, and a warning will be emitted to `SelfLog`. If you actually require multiple configuration sources, the _M.E.C_ builder-pattern is designed to support this, and your syntax will be consistent across configuration sources.
 
@@ -247,6 +247,7 @@ Basic settings of the sink are configured using the properties in a `MSSqlServer
 * `EagerlyEmitFirstEvent`
 * `UseAzureManagedIdentity`
 * `AzureServiceTokenProviderResource`
+* `AzureTenantId`
 
 ### TableName
 

--- a/sample/AppConfigDemo/AppConfigDemo.csproj
+++ b/sample/AppConfigDemo/AppConfigDemo.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>AppConfigDemo</RootNamespace>
     <AssemblyName>AppConfigDemo</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>

--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -4,7 +4,7 @@
     <Description>A Serilog sink that writes events to Microsoft SQL Server</Description>
     <VersionPrefix>5.7.0</VersionPrefix>
     <Authors>Michiel van Oudheusden;Christian Kadluba;Serilog Contributors</Authors>
-    <TargetFrameworks>netstandard2.0;net452;net461;net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net452;net462;net472;netcoreapp3.1</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Sinks.MSSqlServer</AssemblyName>
@@ -67,7 +67,7 @@
     <Compile Include="Configuration\Implementations\Microsoft.Extensions.Configuration\**\*.cs" />
     <Compile Include="Sinks\MSSqlServer\Platform\AzureManagedServiceAuthenticatorStub.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorStub.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/AzureManagedServiceAuthenticatorStub.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
 // This is an empty stub implementaion of IAzureManagedServiceAuthenticator for the target frameworks
-// that don't support Azure Managed Identities (net452, net461, netstandard2.0, netcoreapp2.0).
+// that don't support Azure Managed Identities (net452, net462, netstandard2.0, netcoreapp2.0).
 namespace Serilog.Sinks.MSSqlServer.Platform
 {
     [SuppressMessage("CodeQuality", "IDE0052:Remove unread private members", Justification = "Empty stub but has to implement interface therefore parameters are not used.")]


### PR DESCRIPTION
* Updated target .NET Framework from 4.6.1 to 4.6.2 (4.6.1 reaches end of support in April 2022: https://devblogs.microsoft.com/dotnet/net-framework-4-5-2-4-6-4-6-1-will-reach-end-of-support-on-april-26-2022/)
* Fixed missing "AzureTenantId" in bullet list in README.md.