### PR TITLE
Don't rollback logging if a TransactionScope is rolled back

### DIFF
--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlConnectionFactory.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Platform/SqlConnectionFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.RegularExpressions;
 using Serilog.Sinks.MSSqlServer.Platform.SqlClient;
 
 namespace Serilog.Sinks.MSSqlServer.Platform
@@ -14,6 +15,16 @@ namespace Serilog.Sinks.MSSqlServer.Platform
             if (string.IsNullOrWhiteSpace(connectionString))
             {
                 throw new ArgumentNullException(nameof(connectionString));
+            }
+
+            // Add 'Enlist=false'
+            // unless connectionstring already contains Enlist
+            //  to contain Enlist the word shoudld be at the beginning or after ';'
+            //  and contain a '=' after, with some optional space before or after the word
+            const RegexOptions regexOptions = RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture;
+            if (Regex.IsMatch(connectionString, @"(^|;)\s*Enlist\s*=", regexOptions) == false)
+            {
+                connectionString = connectionString + ";Enlist=false";
             }
 
             _connectionString = connectionString;

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlConnectionFactoryTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Platform/SqlConnectionFactoryTests.cs
@@ -51,7 +51,25 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Platform
             using (var connection = sut.Create())
             {
                 // Assert
-                Assert.Equal(DatabaseFixture.LogEventsConnectionString, connection.ConnectionString);
+                Assert.Equal(DatabaseFixture.LogEventsConnectionString + ";Enlist=false", connection.ConnectionString);
+            }
+        }
+
+        [Theory]
+        [InlineData(DatabaseFixture.LogEventsConnectionString+ "; enlist = True")]
+        [InlineData(DatabaseFixture.LogEventsConnectionString + ";Enlist=False")]
+        [InlineData(" enlist= true;" + DatabaseFixture.LogEventsConnectionString)]
+        [InlineData("Enlist = false;" + DatabaseFixture.LogEventsConnectionString)]
+        public void CreatesSqlConnectionWithSpecifiedConnectionStringWithAndEnlistSet(string connectionString)
+        {
+            // Arrange
+            var sut = new SqlConnectionFactory(connectionString, false, _azureManagedServiceAuthenticatorMock.Object);
+
+            // Act
+            using (var connection = sut.Create())
+            {
+                // Assert
+                Assert.Equal(connectionString, connection.ConnectionString);
             }
         }
 

--- a/test/Serilog.Sinks.MSSqlServer.Tests/TestUtils/DatabaseFixture.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/TestUtils/DatabaseFixture.cs
@@ -32,7 +32,7 @@ DROP DATABASE [{Database}]
 
         public static string Database => "LogTest";
         public static string LogTableName => "LogEvents";
-        public static string LogEventsConnectionString => $@"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog={Database};Integrated Security=True";
+        public const string LogEventsConnectionString = @"Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=LogTest;Integrated Security=True";
 
         public DatabaseFixture()
         {


### PR DESCRIPTION
Automatically add Enlist=false to connectionstring so transaction will not affect logging

Nothing is done if Enlist is already part of the connection string

Fix #24 