### PR TITLE
Fixed issue #624

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 8.2.2
+* Fixed issue #624: Enforce new version of transient dependency to fix vulnerability and avoid nuget.org version de-listing until SqlClient 6.1 is released.
+
 # 8.2.1
 * Updated SqlClient to 5.2.3 (thanks to @cancakar35)
 * Fixes in .editorconfig (thanks to @cancakar35)

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.71.1" />
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.1" />
     <PackageVersion Include="Dapper.StrongName" Version="2.1.35" />

--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+    <PackageReference Include="Microsoft.Identity.Client" />
     <PackageReference Include="Serilog" />
   </ItemGroup>
 


### PR DESCRIPTION
* Fixed issue #624: Enforce new version of transient dependency to fix vulnerability and avoid nuget.org version de-listing until SqlClient 6.1 is released.
* Update CHANGES.md for release 8.2.2