### PR TITLE
Fixed issue #642: package downgrade error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 9.0.1
+* Fixed issue #642: NuGet package downgrade System.Configuration.ConfigurationManager error
+* Updated sample apps to .NET 9
+
 # 9.0.0
 * Updated SqlClient to 6.1.1 and removed Azure.Identity workaround for issue #624
 * Updated all dependencies except .NET 9 NuGets

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="9.0.10" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />

--- a/sample/CombinedConfigDemo/CombinedConfigDemo.csproj
+++ b/sample/CombinedConfigDemo/CombinedConfigDemo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sample/CustomLogEventFormatterDemo/CustomLogEventFormatterDemo.csproj
+++ b/sample/CustomLogEventFormatterDemo/CustomLogEventFormatterDemo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sample/NetStandardDemo/NetStandardDemoApp/NetStandardDemoApp.csproj
+++ b/sample/NetStandardDemo/NetStandardDemoApp/NetStandardDemoApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sample/WorkerServiceDemo/WorkerServiceDemo.csproj
+++ b/sample/WorkerServiceDemo/WorkerServiceDemo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <UserSecretsId>dotnet-WorkerServiceDemo-A4DFF8A6-AC69-443B-A3B8-34E284CD1C78</UserSecretsId>
   </PropertyGroup>
 


### PR DESCRIPTION
* Updated System.Configuration.ConfigurationManager to 9.0.10 to fix issue #642
* Updated sample apps to .NET 9
* Updated CHANGES.md

No major version bump because System.Configuration.ConfigurationManager 9.0.4 was already referenced transitively.