### PR TITLE
Release 9.0.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 9.0.2
+* Fixed issue #643: TraceId and SpanId are saved as empty string instead of NULL (thanks to @nanny07)
+
 # 9.0.1
 * Fixed issue #642: NuGet package downgrade System.Configuration.ConfigurationManager error
 * Updated sample apps to .NET 9

--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A Serilog sink that writes events to Microsoft SQL Server and Azure SQL</Description>
-    <VersionPrefix>9.0.1</VersionPrefix>
+    <VersionPrefix>9.0.2</VersionPrefix>
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageValidationBaselineVersion>9.0.0</PackageValidationBaselineVersion>
     <Authors>Michiel van Oudheusden;Christian Kadluba;Serilog Contributors</Authors>

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/StandardColumnDataGenerator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/StandardColumnDataGenerator.cs
@@ -51,16 +51,16 @@ namespace Serilog.Sinks.MSSqlServer.Output
                 case StandardColumn.Level:
                     return new KeyValuePair<string, object>(_columnOptions.Level.ColumnName, _columnOptions.Level.StoreAsEnum ? (object)logEvent.Level : logEvent.Level.ToString());
                 case StandardColumn.TraceId:
-                    var userDefaultTraceIdValue = logEvent.TraceId is null && !_columnOptions.TraceId.AllowNull;
-                    return new KeyValuePair<string, object>(_columnOptions.TraceId.ColumnName, userDefaultTraceIdValue ? _columnOptions.TraceId.AsDataColumn().DefaultValue.ToString() : logEvent.TraceId?.ToString());
+                    var useDefaultTraceIdValue = logEvent.TraceId is null && !_columnOptions.TraceId.AllowNull;
+                    return new KeyValuePair<string, object>(_columnOptions.TraceId.ColumnName, useDefaultTraceIdValue ? _columnOptions.TraceId.AsDataColumn().DefaultValue.ToString() : logEvent.TraceId?.ToString());
                 case StandardColumn.SpanId:
-                    var userDefaultSpanIdValue = logEvent.SpanId is null && !_columnOptions.SpanId.AllowNull;
-                    return new KeyValuePair<string, object>(_columnOptions.SpanId.ColumnName, userDefaultSpanIdValue ? _columnOptions.SpanId.AsDataColumn().DefaultValue.ToString() : logEvent.SpanId?.ToString());
+                    var useDefaultSpanIdValue = logEvent.SpanId is null && !_columnOptions.SpanId.AllowNull;
+                    return new KeyValuePair<string, object>(_columnOptions.SpanId.ColumnName, useDefaultSpanIdValue ? _columnOptions.SpanId.AsDataColumn().DefaultValue.ToString() : logEvent.SpanId?.ToString());
                 case StandardColumn.TimeStamp:
                     return GetTimeStampStandardColumnNameAndValue(logEvent);
                 case StandardColumn.Exception:
-                    var userDefaultExceptionValue = logEvent.Exception is null && !_columnOptions.Exception.AllowNull;
-                    return new KeyValuePair<string, object>(_columnOptions.Exception.ColumnName, userDefaultExceptionValue ? _columnOptions.Exception.AsDataColumn().DefaultValue.ToString() : logEvent.Exception?.ToString().TruncateOutput(_columnOptions.Exception.DataLength));
+                    var useDefaultExceptionValue = logEvent.Exception is null && !_columnOptions.Exception.AllowNull;
+                    return new KeyValuePair<string, object>(_columnOptions.Exception.ColumnName, useDefaultExceptionValue ? _columnOptions.Exception.AsDataColumn().DefaultValue.ToString() : logEvent.Exception?.ToString().TruncateOutput(_columnOptions.Exception.DataLength));
                 case StandardColumn.Properties:
                     return new KeyValuePair<string, object>(_columnOptions.Properties.ColumnName, ConvertPropertiesToXmlStructure(logEvent.Properties));
                 case StandardColumn.LogEvent:

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/StandardColumnDataGenerator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/StandardColumnDataGenerator.cs
@@ -51,9 +51,9 @@ namespace Serilog.Sinks.MSSqlServer.Output
                 case StandardColumn.Level:
                     return new KeyValuePair<string, object>(_columnOptions.Level.ColumnName, _columnOptions.Level.StoreAsEnum ? (object)logEvent.Level : logEvent.Level.ToString());
                 case StandardColumn.TraceId:
-                    return new KeyValuePair<string, object>(_columnOptions.TraceId.ColumnName, logEvent.TraceId.ToString());
+                    return new KeyValuePair<string, object>(_columnOptions.TraceId.ColumnName, logEvent.TraceId?.ToString());
                 case StandardColumn.SpanId:
-                    return new KeyValuePair<string, object>(_columnOptions.SpanId.ColumnName, logEvent.SpanId.ToString());
+                    return new KeyValuePair<string, object>(_columnOptions.SpanId.ColumnName, logEvent.SpanId?.ToString());
                 case StandardColumn.TimeStamp:
                     return GetTimeStampStandardColumnNameAndValue(logEvent);
                 case StandardColumn.Exception:

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/StandardColumnDataGenerator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/StandardColumnDataGenerator.cs
@@ -51,13 +51,16 @@ namespace Serilog.Sinks.MSSqlServer.Output
                 case StandardColumn.Level:
                     return new KeyValuePair<string, object>(_columnOptions.Level.ColumnName, _columnOptions.Level.StoreAsEnum ? (object)logEvent.Level : logEvent.Level.ToString());
                 case StandardColumn.TraceId:
-                    return new KeyValuePair<string, object>(_columnOptions.TraceId.ColumnName, logEvent.TraceId?.ToString());
+                    var userDefaultTraceIdValue = logEvent.TraceId is null && !_columnOptions.TraceId.AllowNull;
+                    return new KeyValuePair<string, object>(_columnOptions.TraceId.ColumnName, userDefaultTraceIdValue ? _columnOptions.TraceId.AsDataColumn().DefaultValue.ToString() : logEvent.TraceId?.ToString());
                 case StandardColumn.SpanId:
-                    return new KeyValuePair<string, object>(_columnOptions.SpanId.ColumnName, logEvent.SpanId?.ToString());
+                    var userDefaultSpanIdValue = logEvent.SpanId is null && !_columnOptions.SpanId.AllowNull;
+                    return new KeyValuePair<string, object>(_columnOptions.SpanId.ColumnName, userDefaultSpanIdValue ? _columnOptions.SpanId.AsDataColumn().DefaultValue.ToString() : logEvent.SpanId?.ToString());
                 case StandardColumn.TimeStamp:
                     return GetTimeStampStandardColumnNameAndValue(logEvent);
                 case StandardColumn.Exception:
-                    return new KeyValuePair<string, object>(_columnOptions.Exception.ColumnName, logEvent.Exception?.ToString().TruncateOutput(_columnOptions.Exception.DataLength));
+                    var userDefaultExceptionValue = logEvent.Exception is null && !_columnOptions.Exception.AllowNull;
+                    return new KeyValuePair<string, object>(_columnOptions.Exception.ColumnName, userDefaultExceptionValue ? _columnOptions.Exception.AsDataColumn().DefaultValue.ToString() : logEvent.Exception?.ToString().TruncateOutput(_columnOptions.Exception.DataLength));
                 case StandardColumn.Properties:
                     return new KeyValuePair<string, object>(_columnOptions.Properties.ColumnName, ConvertPropertiesToXmlStructure(logEvent.Properties));
                 case StandardColumn.LogEvent:

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/StandardColumnDataGeneratorTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/StandardColumnDataGeneratorTests.cs
@@ -302,6 +302,27 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Output
         }
 
         [Fact]
+        public void GetStandardColumnNameAndNullValueForTraceIdWithoutAllowNullReturnsLogLevelKeyValueEmpty()
+        {
+            // Arrange
+            var traceId = default(ActivityTraceId);
+            var logEvent = new LogEvent(
+                new DateTimeOffset(2020, 1, 1, 0, 0, 0, 0, TimeSpan.Zero),
+                LogEventLevel.Debug, null, new MessageTemplate(new List<MessageTemplateToken>() { new TextToken("Test message") }),
+                new List<LogEventProperty>(), traceId, ActivitySpanId.CreateRandom());
+            var columnOptions = new MSSqlServer.ColumnOptions();
+            columnOptions.TraceId.AllowNull = false;
+            SetupSut(columnOptions, CultureInfo.InvariantCulture);
+
+            // Act
+            var result = _sut.GetStandardColumnNameAndValue(StandardColumn.TraceId, logEvent);
+
+            // Assert
+            Assert.Equal("TraceId", result.Key);
+            Assert.Equal(string.Empty, result.Value);
+        }
+
+        [Fact]
         public void GetStandardColumnNameAndValueForSpanIdReturnsLogLevelKeyValue()
         {
             // Arrange
@@ -337,6 +358,27 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Output
             // Assert
             Assert.Equal("SpanId", result.Key);
             Assert.Null(result.Value);
+        }
+
+        [Fact]
+        public void GetStandardColumnNameAndNullValueForSpanIdWithoutAllowNullReturnsLogLevelKeyValueEmpty()
+        {
+            // Arrange
+            var spanId = default(ActivitySpanId);
+            var logEvent = new LogEvent(
+                new DateTimeOffset(2020, 1, 1, 0, 0, 0, 0, TimeSpan.Zero),
+                LogEventLevel.Debug, null, new MessageTemplate(new List<MessageTemplateToken>() { new TextToken("Test message") }),
+                new List<LogEventProperty>(), ActivityTraceId.CreateRandom(), spanId);
+            var columnOptions = new MSSqlServer.ColumnOptions();
+            columnOptions.SpanId.AllowNull = false;
+            SetupSut(columnOptions, CultureInfo.InvariantCulture);
+
+            // Act
+            var result = _sut.GetStandardColumnNameAndValue(StandardColumn.SpanId, logEvent);
+
+            // Assert
+            Assert.Equal("SpanId", result.Key);
+            Assert.Equal(string.Empty, result.Value);
         }
 
         [Fact]
@@ -485,6 +527,27 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Output
             // Assert
             Assert.Equal("Exception", result.Key);
             Assert.Null(result.Value);
+        }
+
+        [Fact]
+        public void GetStandardColumnNameAndValueForExceptionWhenCalledWithoutExceptionAndNotAllowedNullReturnsEmptyValue()
+        {
+            // Arrange
+            var logEvent = new LogEvent(
+                new DateTimeOffset(2020, 1, 1, 0, 0, 0, 0, TimeSpan.Zero),
+                LogEventLevel.Debug, null, new MessageTemplate(new List<MessageTemplateToken>() { new TextToken("Test message") }),
+                new List<LogEventProperty>());
+            var columnOptions = new Serilog.Sinks.MSSqlServer.ColumnOptions();
+            columnOptions.Level.StoreAsEnum = true;
+            columnOptions.Exception.AllowNull = false;
+            SetupSut(columnOptions, CultureInfo.InvariantCulture);
+
+            // Act
+            var result = _sut.GetStandardColumnNameAndValue(StandardColumn.Exception, logEvent);
+
+            // Assert
+            Assert.Equal("Exception", result.Key);
+            Assert.Equal(string.Empty, result.Value);
         }
 
         [Fact]

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/StandardColumnDataGeneratorTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/StandardColumnDataGeneratorTests.cs
@@ -283,6 +283,25 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Output
         }
 
         [Fact]
+        public void GetStandardColumnNameAndNullValueForTraceIdReturnsLogLevelKeyValue()
+        {
+            // Arrange
+            var traceId = default(ActivityTraceId);
+            var logEvent = new LogEvent(
+                new DateTimeOffset(2020, 1, 1, 0, 0, 0, 0, TimeSpan.Zero),
+                LogEventLevel.Debug, null, new MessageTemplate(new List<MessageTemplateToken>() { new TextToken("Test message") }),
+                new List<LogEventProperty>(), traceId, ActivitySpanId.CreateRandom());
+            SetupSut(new MSSqlServer.ColumnOptions(), CultureInfo.InvariantCulture);
+
+            // Act
+            var result = _sut.GetStandardColumnNameAndValue(StandardColumn.TraceId, logEvent);
+
+            // Assert
+            Assert.Equal("TraceId", result.Key);
+            Assert.Null(result.Value);
+        }
+
+        [Fact]
         public void GetStandardColumnNameAndValueForSpanIdReturnsLogLevelKeyValue()
         {
             // Arrange
@@ -299,6 +318,25 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Output
             // Assert
             Assert.Equal("SpanId", result.Key);
             Assert.Equal("0390190b09823700", result.Value);
+        }
+
+        [Fact]
+        public void GetStandardColumnNameAndNullValueForSpanIdReturnsLogLevelKeyValue()
+        {
+            // Arrange
+            var spanId = default(ActivitySpanId);
+            var logEvent = new LogEvent(
+                new DateTimeOffset(2020, 1, 1, 0, 0, 0, 0, TimeSpan.Zero),
+                LogEventLevel.Debug, null, new MessageTemplate(new List<MessageTemplateToken>() { new TextToken("Test message") }),
+                new List<LogEventProperty>(), ActivityTraceId.CreateRandom(), spanId);
+            SetupSut(new MSSqlServer.ColumnOptions(), CultureInfo.InvariantCulture);
+
+            // Act
+            var result = _sut.GetStandardColumnNameAndValue(StandardColumn.SpanId, logEvent);
+
+            // Assert
+            Assert.Equal("SpanId", result.Key);
+            Assert.Null(result.Value);
         }
 
         [Fact]


### PR DESCRIPTION
* Fixed issue #643: TraceId and SpanId are saved as empty string instead of NULL (thanks to @nanny07)