### PR TITLE
Fix UTC handling for TimeStamp column with ConvertToUtc=true

### DIFF
--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/StandardColumnDataGenerator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/StandardColumnDataGenerator.cs
@@ -77,7 +77,7 @@ namespace Serilog.Sinks.MSSqlServer.Output
             if (_columnOptions.TimeStamp.DataType == SqlDbType.DateTimeOffset)
                 return new KeyValuePair<string, object>(_columnOptions.TimeStamp.ColumnName, dateTimeOffset);
 
-            return new KeyValuePair<string, object>(_columnOptions.TimeStamp.ColumnName, dateTimeOffset.DateTime);
+            return new KeyValuePair<string, object>(_columnOptions.TimeStamp.ColumnName, _columnOptions.TimeStamp.ConvertToUtc ? dateTimeOffset.UtcDateTime : dateTimeOffset.DateTime);
         }
 
         private string RenderLogEventColumn(LogEvent logEvent)

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/StandardColumnDataGeneratorTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/StandardColumnDataGeneratorTests.cs
@@ -487,6 +487,29 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Output
             Assert.Equal(new TimeSpan(0), timeStampColumnOffset.Offset);
         }
 
+        [Trait("Bugfix", "#659")]
+        [Fact]
+        public void GetStandardColumnNameAndValueForTimeStampCreatesUtcDateTimeUsingUtcDateTimeProperty()
+        {
+            // Arrange
+            var options = new Serilog.Sinks.MSSqlServer.ColumnOptions
+            {
+                TimeStamp = { ConvertToUtc = true }
+            };
+            var testDateTimeOffset = new DateTimeOffset(2020, 1, 1, 9, 0, 0, new TimeSpan(1, 0, 0)); // Timezone +1:00
+            var logEvent = CreateLogEvent(testDateTimeOffset);
+            SetupSut(options, CultureInfo.InvariantCulture);
+
+            // Act
+            var column = _sut.GetStandardColumnNameAndValue(StandardColumn.TimeStamp, logEvent);
+
+            // Assert
+            Assert.IsType<DateTime>(column.Value);
+            var timestamp = (DateTime)column.Value;
+            Assert.Equal(testDateTimeOffset.Hour - 1, timestamp.Hour);
+            Assert.Equal(DateTimeKind.Utc, timestamp.Kind);
+        }
+
         [Fact]
         public void GetStandardColumnNameAndValueForExceptionReturnsExceptionKeyValue()
         {


### PR DESCRIPTION
This pull request addresses a bug related to timestamp handling in the MSSqlServer sink, ensuring that timestamps are correctly converted to UTC when the `ConvertToUtc` option is set. It also adds a corresponding unit test to verify this behavior.

**Bugfix: Timestamp UTC conversion**

* Updated `GetTimeStampStandardColumnNameAndValue` in `StandardColumnDataGenerator.cs` to use `UtcDateTime` for the timestamp value when `ConvertToUtc` is enabled, ensuring correct UTC storage.

**Testing improvements**

* Added a unit test `GetStandardColumnNameAndValueForTimeStampCreatesUtcDateTimeUsingUtcDateTimeProperty` in `StandardColumnDataGeneratorTests.cs` to verify that the timestamp is converted to UTC and stored as a `DateTime` with `DateTimeKind.Utc` when `ConvertToUtc` is set.

Closes #659 