### PR TITLE
Changed Level column default DataLength

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ If `DataLength` is set to a value different to -1 longer text will be truncated.
 
 ### Level
 
-This column stores the event level (Error, Information, etc.). For backwards-compatibility reasons it defaults to a length of 16 characters. Alternately, the `StoreAsEnum` property can be set to `true` which causes the underlying level enum integer value to be stored as a SQL `tinyint` column. The `DataType` property can only be set to `nvarchar` or `tinyint`. Setting the `DataType` to `tinyint` is identical to setting `StoreAsEnum` to `true`.
+This column stores the event level (Error, Information, etc.). It defaults to `nvarchar(16)`. Alternately, the `StoreAsEnum` property can be set to `true` which causes the underlying level enum integer value to be stored as a SQL `tinyint` column. The `DataType` property can only be set to `nvarchar` or `tinyint`. Setting the `DataType` to `tinyint` is identical to setting `StoreAsEnum` to `true`.
 
 ### TimeStamp
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ CREATE TABLE [Logs] (
    [Id] int IDENTITY(1,1) NOT NULL,
    [Message] nvarchar(max) NULL,
    [MessageTemplate] nvarchar(max) NULL,
-   [Level] nvarchar(max) NULL,
+   [Level] nvarchar(16) NULL,
    [TimeStamp] datetime NULL,
    [Exception] nvarchar(max) NULL,
    [Properties] nvarchar(max) NULL
@@ -493,7 +493,7 @@ If `DataLength` is set to a value different to -1 longer text will be truncated.
 
 ### Level
 
-This column stores the event level (Error, Information, etc.). For backwards-compatibility reasons it defaults to a length of `nvarchar(max)` characters, but 12 characters is recommended. Alternately, the `StoreAsEnum` property can be set to `true` which causes the underlying level enum integer value to be stored as a SQL `tinyint` column. The `DataType` property can only be set to `nvarchar` or `tinyint`. Setting the `DataType` to `tinyint` is identical to setting `StoreAsEnum` to `true`.
+This column stores the event level (Error, Information, etc.). For backwards-compatibility reasons it defaults to a length of 16 characters. Alternately, the `StoreAsEnum` property can be set to `true` which causes the underlying level enum integer value to be stored as a SQL `tinyint` column. The `DataType` property can only be set to `nvarchar` or `tinyint`. Setting the `DataType` to `tinyint` is identical to setting `StoreAsEnum` to `true`.
 
 ### TimeStamp
 

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/LevelColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/LevelColumnOptions.cs
@@ -17,6 +17,7 @@ namespace Serilog.Sinks.MSSqlServer
             {
                 StandardColumnIdentifier = StandardColumn.Level;
                 DataType = SqlDbType.NVarChar;
+                DataLength = 16;
             }
 
             /// <summary>


### PR DESCRIPTION
Changed default DataLength of Level column from nvarchar(max) to 16 for performance reasons.

Issue: #658