### PR TITLE
Release 9.0.3

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: bin
-          path: src\Serilog.Sinks.MSSqlServer\bin\Release\net8.0
+          path: src\Serilog.Sinks.MSSqlServer\bin\Release\net10.0
 
       - name: Upload testresults artifact with code coverage file
         uses: actions/upload-artifact@v4

--- a/Build.ps1
+++ b/Build.ps1
@@ -73,7 +73,7 @@ try
 
             # Run tests for different targets in sequence to avoid database tests
             # to fail because of concurrency problems
-            foreach ($tfm in @( "net462", "net472", "net8.0" ))
+            foreach ($tfm in @( "net462", "net472", "net8.0", "net10.0" ))
             {
                 echo "build: Testing project in $testProjectPath for target $tfm"
                 & dotnet test -c Release --collect "XPlat Code Coverage" --framework "$tfm" --results-directory "./TestResults/$tfm"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 9.0.3
+* Fixed issue #659: If Timestamp column is set to UTC, Timestamp property in LogEvent column should be UTC too (thanks to @marcominerva)
+* Implemented #658: Preset in 16 or 20 as DataLength for LevelColumn
+* Updated to Serilog 4.3.1
+* Added .NET 10 target framework
+
 # 9.0.2
 * Fixed issue #643: TraceId and SpanId are saved as empty string instead of NULL (thanks to @nanny07)
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Serilog.Settings.Configuration" Version="8.0.4" />
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ If `DataLength` is set to a value different to -1 longer text will be truncated.
 
 ### Level
 
-This column stores the event level (Error, Information, etc.). For backwards-compatibility reasons it defaults to a length of 16 characters. Alternately, the `StoreAsEnum` property can be set to `true` which causes the underlying level enum integer value to be stored as a SQL `tinyint` column. The `DataType` property can only be set to `nvarchar` or `tinyint`. Setting the `DataType` to `tinyint` is identical to setting `StoreAsEnum` to `true`.
+This column stores the event level (Error, Information, etc.). It defaults to `nvarchar(16)`. Alternately, the `StoreAsEnum` property can be set to `true` which causes the underlying level enum integer value to be stored as a SQL `tinyint` column. The `DataType` property can only be set to `nvarchar` or `tinyint`. Setting the `DataType` to `tinyint` is identical to setting `StoreAsEnum` to `true`.
 
 ### TimeStamp
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ CREATE TABLE [Logs] (
    [Id] int IDENTITY(1,1) NOT NULL,
    [Message] nvarchar(max) NULL,
    [MessageTemplate] nvarchar(max) NULL,
-   [Level] nvarchar(max) NULL,
+   [Level] nvarchar(16) NULL,
    [TimeStamp] datetime NULL,
    [Exception] nvarchar(max) NULL,
    [Properties] nvarchar(max) NULL
@@ -493,7 +493,7 @@ If `DataLength` is set to a value different to -1 longer text will be truncated.
 
 ### Level
 
-This column stores the event level (Error, Information, etc.). For backwards-compatibility reasons it defaults to a length of `nvarchar(max)` characters, but 12 characters is recommended. Alternately, the `StoreAsEnum` property can be set to `true` which causes the underlying level enum integer value to be stored as a SQL `tinyint` column. The `DataType` property can only be set to `nvarchar` or `tinyint`. Setting the `DataType` to `tinyint` is identical to setting `StoreAsEnum` to `true`.
+This column stores the event level (Error, Information, etc.). For backwards-compatibility reasons it defaults to a length of 16 characters. Alternately, the `StoreAsEnum` property can be set to `true` which causes the underlying level enum integer value to be stored as a SQL `tinyint` column. The `DataType` property can only be set to `nvarchar` or `tinyint`. Setting the `DataType` to `tinyint` is identical to setting `StoreAsEnum` to `true`.
 
 ### TimeStamp
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "allowPrerelease": true,
+    "rollForward": "latestFeature"
+  }
+}

--- a/sample/CombinedConfigDemo/CombinedConfigDemo.csproj
+++ b/sample/CombinedConfigDemo/CombinedConfigDemo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sample/CustomLogEventFormatterDemo/CustomLogEventFormatterDemo.csproj
+++ b/sample/CustomLogEventFormatterDemo/CustomLogEventFormatterDemo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sample/NetStandardDemo/NetStandardDemoApp/NetStandardDemoApp.csproj
+++ b/sample/NetStandardDemo/NetStandardDemoApp/NetStandardDemoApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sample/WorkerServiceDemo/WorkerServiceDemo.csproj
+++ b/sample/WorkerServiceDemo/WorkerServiceDemo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <UserSecretsId>dotnet-WorkerServiceDemo-A4DFF8A6-AC69-443B-A3B8-34E284CD1C78</UserSecretsId>
   </PropertyGroup>
 

--- a/serilog-sinks-mssqlserver.sln
+++ b/serilog-sinks-mssqlserver.sln
@@ -35,6 +35,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 		.github\workflows\release.yml = .github\workflows\release.yml
 		RunPerfTests.ps1 = RunPerfTests.ps1
+		global.json = global.json
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetStandardDemoLib", "sample\NetStandardDemo\NetStandardDemoLib\NetStandardDemoLib.csproj", "{8E69E31B-61C7-4175-B886-9C2078FCA477}"

--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -6,7 +6,7 @@
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageValidationBaselineVersion>9.0.0</PackageValidationBaselineVersion>
     <Authors>Michiel van Oudheusden;Christian Kadluba;Serilog Contributors</Authors>
-    <TargetFrameworks>netstandard2.0;net462;net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net472;net8.0;net10.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Sinks.MSSqlServer</AssemblyName>
@@ -58,7 +58,7 @@
     <Compile Include="Configuration\Implementations\Microsoft.Extensions.Configuration\**\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net462' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' Or '$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="System.Configuration.ConfigurationManager" />
     <Compile Include="Configuration\Extensions\Hybrid\**\*.cs" />
     <Compile Include="Configuration\Implementations\Microsoft.Extensions.Configuration\**\*.cs" />

--- a/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
+++ b/src/Serilog.Sinks.MSSqlServer/Serilog.Sinks.MSSqlServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A Serilog sink that writes events to Microsoft SQL Server and Azure SQL</Description>
-    <VersionPrefix>9.0.2</VersionPrefix>
+    <VersionPrefix>9.0.3</VersionPrefix>
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageValidationBaselineVersion>9.0.0</PackageValidationBaselineVersion>
     <Authors>Michiel van Oudheusden;Christian Kadluba;Serilog Contributors</Authors>

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/LevelColumnOptions.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/ColumnOptions/LevelColumnOptions.cs
@@ -17,6 +17,7 @@ namespace Serilog.Sinks.MSSqlServer
             {
                 StandardColumnIdentifier = StandardColumn.Level;
                 DataType = SqlDbType.NVarChar;
+                DataLength = 16;
             }
 
             /// <summary>

--- a/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/StandardColumnDataGenerator.cs
+++ b/src/Serilog.Sinks.MSSqlServer/Sinks/MSSqlServer/Output/StandardColumnDataGenerator.cs
@@ -77,7 +77,7 @@ namespace Serilog.Sinks.MSSqlServer.Output
             if (_columnOptions.TimeStamp.DataType == SqlDbType.DateTimeOffset)
                 return new KeyValuePair<string, object>(_columnOptions.TimeStamp.ColumnName, dateTimeOffset);
 
-            return new KeyValuePair<string, object>(_columnOptions.TimeStamp.ColumnName, dateTimeOffset.DateTime);
+            return new KeyValuePair<string, object>(_columnOptions.TimeStamp.ColumnName, _columnOptions.TimeStamp.ConvertToUtc ? dateTimeOffset.UtcDateTime : dateTimeOffset.DateTime);
         }
 
         private string RenderLogEventColumn(LogEvent logEvent)

--- a/test/Serilog.Sinks.MSSqlServer.PerformanceTests/Serilog.Sinks.MSSqlServer.PerformanceTests.csproj
+++ b/test/Serilog.Sinks.MSSqlServer.PerformanceTests/Serilog.Sinks.MSSqlServer.PerformanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Serilog.Sinks.MSSqlServer.PerformanceTests</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -17,5 +17,5 @@
     <PackageReference Include="BenchmarkDotNet" />
     <PackageReference Include="Moq" />
   </ItemGroup>
-  
+
 </Project>

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Serilog.Sinks.MSSqlServer.Tests.csproj
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Serilog.Sinks.MSSqlServer.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net472;net8.0;net10.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Serilog.Sinks.MSSqlServer.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
@@ -44,7 +44,7 @@
     <Compile Include="Configuration\Implementations\System.Configuration\**\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' Or '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/StandardColumnDataGeneratorTests.cs
+++ b/test/Serilog.Sinks.MSSqlServer.Tests/Sinks/MSSqlServer/Output/StandardColumnDataGeneratorTests.cs
@@ -487,6 +487,29 @@ namespace Serilog.Sinks.MSSqlServer.Tests.Output
             Assert.Equal(new TimeSpan(0), timeStampColumnOffset.Offset);
         }
 
+        [Trait("Bugfix", "#659")]
+        [Fact]
+        public void GetStandardColumnNameAndValueForTimeStampCreatesUtcDateTimeUsingUtcDateTimeProperty()
+        {
+            // Arrange
+            var options = new Serilog.Sinks.MSSqlServer.ColumnOptions
+            {
+                TimeStamp = { ConvertToUtc = true }
+            };
+            var testDateTimeOffset = new DateTimeOffset(2020, 1, 1, 9, 0, 0, new TimeSpan(1, 0, 0)); // Timezone +1:00
+            var logEvent = CreateLogEvent(testDateTimeOffset);
+            SetupSut(options, CultureInfo.InvariantCulture);
+
+            // Act
+            var column = _sut.GetStandardColumnNameAndValue(StandardColumn.TimeStamp, logEvent);
+
+            // Assert
+            Assert.IsType<DateTime>(column.Value);
+            var timestamp = (DateTime)column.Value;
+            Assert.Equal(testDateTimeOffset.Hour - 1, timestamp.Hour);
+            Assert.Equal(DateTimeKind.Utc, timestamp.Kind);
+        }
+
         [Fact]
         public void GetStandardColumnNameAndValueForExceptionReturnsExceptionKeyValue()
         {


### PR DESCRIPTION
* Fixed issue #659: If Timestamp column is set to UTC, Timestamp property in LogEvent column should be UTC too (thanks to @marcominerva)
* Implemented #658: Preset in 16 or 20 as DataLength for LevelColumn
* Updated to Serilog 4.3.1
* Added .NET 10 target framework
